### PR TITLE
Allow Layers to be constructed from input shapes

### DIFF
--- a/lasagne/layers/base.py
+++ b/lasagne/layers/base.py
@@ -23,22 +23,22 @@ class Layer(object):
     network's output :class:`Layer` instance can double as a handle to the
     full network.
     """
-    def __init__(self, input_layer, name=None):
+    def __init__(self, incoming, name=None):
         """
         Instantiates the layer.
 
         :parameters:
-            - input_layer : a :class:`Layer` instance or a tuple
+            - incoming : a :class:`Layer` instance or a tuple
                 the layer feeding into this layer, or the expected input shape
             - name : a string or None
                 an optional name to attach to this layer
         """
-        if isinstance(input_layer, tuple):
-            self.input_shape = input_layer
+        if isinstance(incoming, tuple):
+            self.input_shape = incoming
             self.input_layer = None
         else:
-            self.input_shape = input_layer.get_output_shape()
-            self.input_layer = input_layer
+            self.input_shape = incoming.get_output_shape()
+            self.input_layer = incoming
         self.name = name
 
     def get_params(self):
@@ -246,22 +246,22 @@ class MultipleInputsLayer(Layer):
     It should be subclassed when implementing new types of layers that
     obtain their input from multiple layers.
     """
-    def __init__(self, input_layers, name=None):
+    def __init__(self, incomings, name=None):
         """
         Instantiates the layer.
 
         :parameters:
-            - input_layers : a list of :class:`Layer` instances or tuples
+            - incomings : a list of :class:`Layer` instances or tuples
                 the layers feeding into this layer, or expected input shapes
             - name : a string or None
                 an optional name to attach to this layer
         """
-        self.input_shapes = [input_layer if isinstance(input_layer, tuple)
-                             else input_layer.get_output_shape()
-                             for input_layer in input_layers]
-        self.input_layers = [None if isinstance(input_layer, tuple)
-                             else input_layer
-                             for input_layer in input_layers]
+        self.input_shapes = [incoming if isinstance(incoming, tuple)
+                             else incoming.get_output_shape()
+                             for incoming in incomings]
+        self.input_layers = [None if isinstance(incoming, tuple)
+                             else incoming
+                             for incoming in incomings]
         self.name = name
 
     def get_output_shape(self):

--- a/lasagne/layers/conv.py
+++ b/lasagne/layers/conv.py
@@ -16,10 +16,10 @@ __all__ = [
 
 
 class Conv1DLayer(Layer):
-    def __init__(self, input_layer, num_filters, filter_length, stride=1, border_mode="valid", untie_biases=False,
+    def __init__(self, incoming, num_filters, filter_length, stride=1, border_mode="valid", untie_biases=False,
                  W=init.Uniform(), b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
                  convolution=conv.conv1d_mc0, **kwargs):
-        super(Conv1DLayer, self).__init__(input_layer, **kwargs)
+        super(Conv1DLayer, self).__init__(incoming, **kwargs)
         if nonlinearity is None:
             self.nonlinearity = nonlinearities.identity
         else:
@@ -93,10 +93,10 @@ class Conv1DLayer(Layer):
 
 
 class Conv2DLayer(Layer):
-    def __init__(self, input_layer, num_filters, filter_size, strides=(1, 1), border_mode="valid", untie_biases=False,
+    def __init__(self, incoming, num_filters, filter_size, strides=(1, 1), border_mode="valid", untie_biases=False,
                  W=init.Uniform(), b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
                  convolution=T.nnet.conv2d, **kwargs):
-        super(Conv2DLayer, self).__init__(input_layer, **kwargs)
+        super(Conv2DLayer, self).__init__(incoming, **kwargs)
         if nonlinearity is None:
             self.nonlinearity = nonlinearities.identity
         else:

--- a/lasagne/layers/conv.py
+++ b/lasagne/layers/conv.py
@@ -42,7 +42,7 @@ class Conv1DLayer(Layer):
             self.b = self.create_param(b, (num_filters,), name="b")
 
     def get_W_shape(self):
-        num_input_channels = self.input_layer.get_output_shape()[1]
+        num_input_channels = self.input_shape[1]
         return (self.num_filters, num_input_channels, self.filter_length)
 
     def get_params(self):
@@ -65,9 +65,9 @@ class Conv1DLayer(Layer):
 
     def get_output_for(self, input, input_shape=None, *args, **kwargs):
         # the optional input_shape argument is for when get_output_for is called
-        # directly with a different shape than the output_shape of self.input_layer.
+        # directly with a different shape than self.input_shape.
         if input_shape is None:
-            input_shape = self.input_layer.get_output_shape()
+            input_shape = self.input_shape
 
         filter_shape = self.get_W_shape()
 
@@ -119,7 +119,7 @@ class Conv2DLayer(Layer):
             self.b = self.create_param(b, (num_filters,), name="b")
 
     def get_W_shape(self):
-        num_input_channels = self.input_layer.get_output_shape()[1]
+        num_input_channels = self.input_shape[1]
         return (self.num_filters, num_input_channels, self.filter_size[0], self.filter_size[1])
 
     def get_params(self):
@@ -145,9 +145,9 @@ class Conv2DLayer(Layer):
 
     def get_output_for(self, input, input_shape=None, *args, **kwargs):
         # the optional input_shape argument is for when get_output_for is called
-        # directly with a different shape than the output_shape of self.input_layer.
+        # directly with a different shape than self.input_shape.
         if input_shape is None:
-            input_shape = self.input_layer.get_output_shape()
+            input_shape = self.input_shape
 
         filter_shape = self.get_W_shape()
 

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -76,7 +76,7 @@ class Conv2DMMLayer(MMLayer):
         self.corr_mm_op = GpuCorrMM(subsample=self.strides, pad=self.pad)
 
     def get_W_shape(self):
-        num_input_channels = self.input_layer.get_output_shape()[1]
+        num_input_channels = self.input_shape[1]
         return (self.num_filters, num_input_channels, self.filter_size[0], self.filter_size[1])
 
     def get_params(self):

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -31,10 +31,10 @@ class MMLayer(Layer):
 
 
 class Conv2DMMLayer(MMLayer):
-    def __init__(self, input_layer, num_filters, filter_size, strides=(1, 1), border_mode=None, untie_biases=False,
+    def __init__(self, incoming, num_filters, filter_size, strides=(1, 1), border_mode=None, untie_biases=False,
                  W=init.Uniform(), b=init.Constant(0.), nonlinearity=nonlinearities.rectify, pad=None,
                  flip_filters=False, **kwargs):
-        super(Conv2DMMLayer, self).__init__(input_layer, **kwargs)
+        super(Conv2DMMLayer, self).__init__(incoming, **kwargs)
         if nonlinearity is None:
             self.nonlinearity = nonlinearities.identity
         else:

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -97,10 +97,10 @@ class Conv2DCCLayer(CCLayer):
 
     def get_W_shape(self):
         if self.dimshuffle:
-            num_input_channels = self.input_layer.get_output_shape()[1]
+            num_input_channels = self.input_shape[1]
             return (self.num_filters, num_input_channels, self.filter_size, self.filter_size)
         else:
-            num_input_channels = self.input_layer.get_output_shape()[0]
+            num_input_channels = self.input_shape[0]
             return (num_input_channels, self.filter_size, self.filter_size, self.num_filters)
 
     def get_params(self):
@@ -264,8 +264,7 @@ class NINLayer_c01b(Layer):
         self.num_units = num_units
         self.untie_biases = untie_biases
 
-        output_shape = self.input_layer.get_output_shape()
-        num_input_channels = output_shape[0]
+        num_input_channels = self.input_shape[0]
 
         self.W = self.create_param(W, (num_units, num_input_channels))
         if b is None:

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -37,10 +37,10 @@ class CCLayer(Layer):
 
 
 class Conv2DCCLayer(CCLayer):
-    def __init__(self, input_layer, num_filters, filter_size, strides=(1, 1), border_mode=None, untie_biases=False,
+    def __init__(self, incoming, num_filters, filter_size, strides=(1, 1), border_mode=None, untie_biases=False,
                  W=init.Uniform(), b=init.Constant(0.), nonlinearity=nonlinearities.rectify, pad=None,
                  dimshuffle=True, flip_filters=False, partial_sum=1, **kwargs):
-        super(Conv2DCCLayer, self).__init__(input_layer, **kwargs)
+        super(Conv2DCCLayer, self).__init__(incoming, **kwargs)
         if nonlinearity is None:
             self.nonlinearity = nonlinearities.identity
         else:
@@ -155,10 +155,10 @@ class Conv2DCCLayer(CCLayer):
 
 
 class MaxPool2DCCLayer(CCLayer):
-    def __init__(self, input_layer, ds, ignore_border=False, strides=None, dimshuffle=True, **kwargs):
+    def __init__(self, incoming, ds, ignore_border=False, strides=None, dimshuffle=True, **kwargs):
         from pylearn2.sandbox.cuda_convnet.pool import MaxPool
 
-        super(MaxPool2DCCLayer, self).__init__(input_layer, **kwargs)
+        super(MaxPool2DCCLayer, self).__init__(incoming, **kwargs)
         if ds[0] != ds[1]:
             raise RuntimeError("MaxPool2DCCLayer only supports square pooling regions, but ds=(%d, %d)" % ds)
 
@@ -252,10 +252,10 @@ class NINLayer_c01b(Layer):
     axis arrangement instead of bc01. This reduces the number of shuffles
     and reshapes required and might be faster as a result.
     """
-    def __init__(self, input_layer, num_units, untie_biases=False,
+    def __init__(self, incoming, num_units, untie_biases=False,
         W=init.Uniform(), b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
         **kwargs):
-        super(NINLayer_c01b, self).__init__(input_layer, **kwargs)
+        super(NINLayer_c01b, self).__init__(incoming, **kwargs)
         if nonlinearity is None:
             self.nonlinearity = nonlinearities.identity
         else:

--- a/lasagne/layers/dense.py
+++ b/lasagne/layers/dense.py
@@ -62,8 +62,7 @@ class DenseLayer(Layer):
 
         self.num_units = num_units
 
-        output_shape = self.input_layer.get_output_shape()
-        num_inputs = int(np.prod(output_shape[1:]))
+        num_inputs = int(np.prod(self.input_shape[1:]))
 
         self.W = self.create_param(W, (num_inputs, num_units), name="W")
         self.b = self.create_param(b, (num_units,), name="b") if b is not None else None
@@ -109,8 +108,7 @@ class NINLayer(Layer):
         self.num_units = num_units
         self.untie_biases = untie_biases
 
-        output_shape = self.input_layer.get_output_shape()
-        num_input_channels = output_shape[1]
+        num_input_channels = self.input_shape[1]
 
         self.W = self.create_param(W, (num_input_channels, num_units), name="W")
         if b is None:

--- a/lasagne/layers/dense.py
+++ b/lasagne/layers/dense.py
@@ -52,9 +52,9 @@ class DenseLayer(Layer):
         >>> l_in = InputLayer((100, 20))
         >>> l1 = DenseLayer(l_in, num_units=50)
     """
-    def __init__(self, input_layer, num_units, W=init.Uniform(), b=init.Constant(0.),
+    def __init__(self, incoming, num_units, W=init.Uniform(), b=init.Constant(0.),
         nonlinearity=nonlinearities.rectify, **kwargs):
-        super(DenseLayer, self).__init__(input_layer, **kwargs)
+        super(DenseLayer, self).__init__(incoming, **kwargs)
         if nonlinearity is None:
             self.nonlinearity = nonlinearities.identity
         else:
@@ -96,10 +96,10 @@ class NINLayer(Layer):
     Any number of trailing dimensions is supported, so NINLayer can be used to implement
     1D, 2D, 3D, ... convolutions.
     """
-    def __init__(self, input_layer, num_units, untie_biases=False,
+    def __init__(self, incoming, num_units, untie_biases=False,
         W=init.Uniform(), b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
         **kwargs):
-        super(NINLayer, self).__init__(input_layer, **kwargs)
+        super(NINLayer, self).__init__(incoming, **kwargs)
         if nonlinearity is None:
             self.nonlinearity = nonlinearities.identity
         else:

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -98,7 +98,7 @@ class Conv2DDNNLayer(DNNLayer):
             self.b = self.create_param(b, (num_filters,), name="b")
 
     def get_W_shape(self):
-        num_input_channels = self.input_layer.get_output_shape()[1]
+        num_input_channels = self.input_shape[1]
         return (self.num_filters, num_input_channels, self.filter_size[0], self.filter_size[1])
 
     def get_params(self):

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -25,8 +25,8 @@ class DNNLayer(Layer):
 
 
 class Pool2DDNNLayer(DNNLayer):
-    def __init__(self, input_layer, ds, strides=None, mode='max', **kwargs):
-        super(Pool2DDNNLayer, self).__init__(input_layer, **kwargs)
+    def __init__(self, incoming, ds, strides=None, mode='max', **kwargs):
+        super(Pool2DDNNLayer, self).__init__(incoming, **kwargs)
         self.ds = ds # a tuple
         self.mode = mode
         self.strides = strides if strides is not None else ds
@@ -42,14 +42,14 @@ class Pool2DDNNLayer(DNNLayer):
 
 
 class MaxPool2DDNNLayer(Pool2DDNNLayer): # for consistency
-    def __init__(self, input_layer, ds, strides=None, **kwargs):
-        super(MaxPool2DDNNLayer, self).__init__(input_layer, ds, strides, mode='max', **kwargs)
+    def __init__(self, incoming, ds, strides=None, **kwargs):
+        super(MaxPool2DDNNLayer, self).__init__(incoming, ds, strides, mode='max', **kwargs)
 
 class Conv2DDNNLayer(DNNLayer):
-    def __init__(self, input_layer, num_filters, filter_size, strides=(1, 1), border_mode=None, untie_biases=False,
+    def __init__(self, incoming, num_filters, filter_size, strides=(1, 1), border_mode=None, untie_biases=False,
                  W=init.Uniform(), b=init.Constant(0.), nonlinearity=nonlinearities.rectify, pad=None,
                  flip_filters=False, **kwargs):
-        super(Conv2DDNNLayer, self).__init__(input_layer, **kwargs)
+        super(Conv2DDNNLayer, self).__init__(incoming, **kwargs)
         if nonlinearity is None:
             self.nonlinearity = nonlinearities.identity
         else:

--- a/lasagne/layers/merge.py
+++ b/lasagne/layers/merge.py
@@ -15,8 +15,8 @@ __all__ = [
 
 
 class ConcatLayer(MultipleInputsLayer):
-    def __init__(self, input_layers, axis=1, **kwargs):
-        super(ConcatLayer, self).__init__(input_layers, **kwargs)
+    def __init__(self, incomings, axis=1, **kwargs):
+        super(ConcatLayer, self).__init__(incomings, **kwargs)
         self.axis = axis
 
     def get_output_shape_for(self, input_shapes):
@@ -45,25 +45,26 @@ class ElemwiseSumLayer(MultipleInputsLayer):
     the copy operations in concatenation, but splits up the dot product.)
     """
 
-    def __init__(self, input_layers, coeffs=1, **kwargs):
+    def __init__(self, incomings, coeffs=1, **kwargs):
         """
         Creates a layer perfoming an elementwise sum of its input layers.
 
         :parameters:
-            - input_layers: list
-                A list of :class:`Layer` instances of same output shape to sum
+            - incomings : a list of :class:`Layer` instances or tuples
+                the layers feeding into this layer, or expected input shapes,
+                with all incoming shapes being equal
             - coeffs: list or scalar
                 A same-sized list of coefficients, or a single coefficient that
                 is to be applied to all instances. By default, these will not
                 be included in the learnable parameters of this layer.
         """
-        super(ElemwiseSumLayer, self).__init__(input_layers, **kwargs)
+        super(ElemwiseSumLayer, self).__init__(incomings, **kwargs)
         if isinstance(coeffs, list):
-            if len(coeffs) != len(input_layers):
-                raise ValueError("Mismatch: got %d coeffs for %d input_layers" %
-                                 (len(coeffs), len(input_layers)))
+            if len(coeffs) != len(incomings):
+                raise ValueError("Mismatch: got %d coeffs for %d incomings" %
+                                 (len(coeffs), len(incomings)))
         else:
-            coeffs = [coeffs] * len(input_layers)
+            coeffs = [coeffs] * len(incomings)
         self.coeffs = coeffs
 
     def get_output_shape_for(self, input_shapes):

--- a/lasagne/layers/noise.py
+++ b/lasagne/layers/noise.py
@@ -31,7 +31,7 @@ class DropoutLayer(Layer):
                 input /= retain_prob
 
             # use nonsymbolic shape for dropout mask if possible
-            input_shape = self.input_layer.get_output_shape()
+            input_shape = self.input_shape
             if any(s is None for s in input_shape):
                 input_shape = input.shape
 

--- a/lasagne/layers/noise.py
+++ b/lasagne/layers/noise.py
@@ -17,8 +17,8 @@ __all__ = [
 
 
 class DropoutLayer(Layer):
-    def __init__(self, input_layer, p=0.5, rescale=True, **kwargs):
-        super(DropoutLayer, self).__init__(input_layer, **kwargs)
+    def __init__(self, incoming, p=0.5, rescale=True, **kwargs):
+        super(DropoutLayer, self).__init__(incoming, **kwargs)
         self.p = p
         self.rescale = rescale
 
@@ -42,8 +42,8 @@ dropout = DropoutLayer # shortcut
 
 
 class GaussianNoiseLayer(Layer):
-    def __init__(self, input_layer, sigma=0.1, **kwargs):
-        super(GaussianNoiseLayer, self).__init__(input_layer, **kwargs)
+    def __init__(self, incoming, sigma=0.1, **kwargs):
+        super(GaussianNoiseLayer, self).__init__(incoming, **kwargs)
         self.sigma = sigma
 
     def get_output_for(self, input, deterministic=False, *args, **kwargs):

--- a/lasagne/layers/pool.py
+++ b/lasagne/layers/pool.py
@@ -60,7 +60,7 @@ class FeaturePoolLayer(Layer):
         self.axis = axis
         self.pool_function = pool_function
 
-        num_feature_maps = self.input_layer.get_output_shape()[self.axis]
+        num_feature_maps = self.input_shape[self.axis]
         if num_feature_maps % self.ds != 0:
             raise RuntimeError("Number of input feature maps (%d) is not a multiple of the pool size (ds=%d)" %
                     (num_feature_maps, self.ds))
@@ -103,7 +103,7 @@ class FeatureWTALayer(Layer):
         self.ds = ds
         self.axis = axis
 
-        num_feature_maps = self.input_layer.get_output_shape()[self.axis]
+        num_feature_maps = self.input_shape[self.axis]
         if num_feature_maps % self.ds != 0:
             raise RuntimeError("Number of input feature maps (%d) is not a multiple of the group size (ds=%d)" %
                     (num_feature_maps, self.ds))

--- a/lasagne/layers/pool.py
+++ b/lasagne/layers/pool.py
@@ -16,8 +16,8 @@ __all__ = [
 
 
 class MaxPool2DLayer(Layer):
-    def __init__(self, input_layer, ds, ignore_border=False, **kwargs):
-        super(MaxPool2DLayer, self).__init__(input_layer, **kwargs)
+    def __init__(self, incoming, ds, ignore_border=False, **kwargs):
+        super(MaxPool2DLayer, self).__init__(incoming, **kwargs)
         self.ds = ds # a tuple
         self.ignore_border = ignore_border
 
@@ -48,14 +48,14 @@ class FeaturePoolLayer(Layer):
     IMPORTANT: this layer requires that the number of feature maps is
     a multiple of the pool size.
     """
-    def __init__(self, input_layer, ds, axis=1, pool_function=T.max, **kwargs):
+    def __init__(self, incoming, ds, axis=1, pool_function=T.max, **kwargs):
         """
         ds: the number of feature maps to be pooled together
         axis: the axis along which to pool. The default value of 1 works
         for DenseLayer and Conv*DLayers
         pool_function: the pooling function to use
         """
-        super(FeaturePoolLayer, self).__init__(input_layer, **kwargs)
+        super(FeaturePoolLayer, self).__init__(incoming, **kwargs)
         self.ds = ds
         self.axis = axis
         self.pool_function = pool_function
@@ -92,14 +92,14 @@ class FeatureWTALayer(Layer):
     IMPORTANT: this layer requires that the number of feature maps is
     a multiple of the pool size.
     """
-    def __init__(self, input_layer, ds, axis=1, **kwargs):
+    def __init__(self, incoming, ds, axis=1, **kwargs):
         """
         ds: the number of feature maps per group. This is called 'ds'
         for consistency with the pooling layers, even though this
         layer does not actually perform a downsampling operation.
         axis: the axis along which the groups are formed.
         """
-        super(FeatureWTALayer, self).__init__(input_layer, **kwargs)
+        super(FeatureWTALayer, self).__init__(incoming, **kwargs)
         self.ds = ds
         self.axis = axis
 
@@ -139,8 +139,8 @@ class GlobalPoolLayer(Layer):
     """
     Layer that pools globally across all trailing dimensions beyond the 2nd.
     """
-    def __init__(self, input_layer, pool_function=T.mean, **kwargs):
-        super(GlobalPoolLayer, self).__init__(input_layer, **kwargs)
+    def __init__(self, incoming, pool_function=T.mean, **kwargs):
+        super(GlobalPoolLayer, self).__init__(incoming, **kwargs)
         self.pool_function = pool_function
 
     def get_output_shape_for(self, input_shape):

--- a/lasagne/layers/shape.py
+++ b/lasagne/layers/shape.py
@@ -27,8 +27,8 @@ flatten = FlattenLayer # shortcut
 
 
 class PadLayer(Layer):
-    def __init__(self, input_layer, width, val=0, batch_ndim=2, **kwargs):
-        super(PadLayer, self).__init__(input_layer, **kwargs)
+    def __init__(self, incoming, width, val=0, batch_ndim=2, **kwargs):
+        super(PadLayer, self).__init__(incoming, **kwargs)
         self.width = width
         self.val = val
         self.batch_ndim = batch_ndim

--- a/lasagne/tests/layers/test_dense.py
+++ b/lasagne/tests/layers/test_dense.py
@@ -23,7 +23,7 @@ class TestDenseLayer:
         W.return_value = numpy.ones((12, 3))
         b.return_value = numpy.ones((3,)) * 3
         layer = DenseLayer(
-            input_layer=dummy_input_layer,
+            dummy_input_layer,
             num_units=3,
             W=W,
             b=b,
@@ -50,7 +50,7 @@ class TestDenseLayer:
 
     def test_init_none_nonlinearity(self, DenseLayer, dummy_input_layer):
         layer = DenseLayer(
-            input_layer=dummy_input_layer,
+            dummy_input_layer,
             num_units=3,
             nonlinearity=None,
             )
@@ -103,7 +103,7 @@ class TestDenseLayer:
 
     def test_named_layer_param_names(self, DenseLayer, dummy_input_layer):
         layer = DenseLayer(
-            input_layer=dummy_input_layer,
+            dummy_input_layer,
             num_units=3,
             name = "foo"
             )


### PR DESCRIPTION
As discussed in #17, it seemed to be a good idea to allow Layer instances to be constructed from input shapes rather than other Layer instances. While `get_output()` would not work for such layers, they could still be used standalone with `get_output_for()` and `get_output_shape_for()` -- after all, a layer only needs to know about its input and input shape to function.

We thought that implementing this would only touch the `Layer` base class (and the `MultipleInputsLayer` base class). However, while implementing it, I found that several other layer implementations rely on `self.input_layer.get_output_shape()` to work. There are about four ways of solving it:
1. Distinguishing between `self.input_layer` being a shape tuple or a layer in each of these cases
2. Moving this distinction into a new `get_input_shape()` method in the base class
3. Relying on this distinction being present in `Layer.get_output_shape()` and using `super(XYZLayer, self).get_output_shape()` instead of `self.input_layer.get_output_shape()` (this only works for classes directly derived from `Layer`, because in this case the super `get_output_shape()` will just return the input shape, so that's both ugly and fragile)
4. Wrapping a shape tuple in something that implements `get_output_shape()`

It turns out that we have a ready-made class for option 4, which is `InputLayer`. By wrapping shape tuples given in the constructor in `InputLayer` instances, only the base classes need to be changed. However, it feels like an unnecessary / misplaced shortcut now... what do we gain compared to requiring the user to provide an `InputLayer` instance herself or himself? Should we possibly choose option 2 instead? Should we create an `InputShape` class that really just wraps a shape tuple with a `get_output_shape()` method? Or is this proposal a good solution anyway?