### PR TITLE
Add ReshapeLayer

### DIFF
--- a/lasagne/layers/shape.py
+++ b/lasagne/layers/shape.py
@@ -10,6 +10,7 @@ from .base import Layer
 __all__ = [
     "FlattenLayer",
     "flatten",
+    "ReshapeLayer",
     "PadLayer",
     "pad",
 ]
@@ -24,6 +25,78 @@ class FlattenLayer(Layer):
         return input.flatten(2)
 
 flatten = FlattenLayer # shortcut
+
+
+class ReshapeLayer(Layer):
+    """
+    A layer reshaping its input tensor to another tensor of the same total
+    number of elements.
+
+    :parameters:
+        - incoming : a :class:`Layer` instance or a tuple
+            the layer feeding into this layer, or the expected input shape
+
+        - shape : tuple
+            The target shape. Any of its elements can be `None`, denoting to
+            retain the size of the input shape for this dimension. At most one
+            element can be `-1`, denoting to infer the size for this dimension
+            to match the total number of elements of the input shape. Any
+            remaining elements must be positive integers.
+
+    :usage:
+        >>> from lasagne.layers import InputLayer, ReshapeLayer
+        >>> l_in = InputLayer((100, 20))
+        >>> l1 = ReshapeLayer(l_in, (None, 2, 10))
+        >>> l1.get_output_shape()
+        (100, 2, 10)
+        >>> l2 = ReshapeLayer(l_in, (None, 1, 2, 5, -1))
+        >>> l2.get_output_shape()
+        (100, 1, 2, 5, 2)
+
+    :note:
+        The tensor elements will be fetched and placed in C-like order. That
+        is, reshaping `[1,2,3,4,5,6]` to shape `(2,3)` will result in a matrix
+        `[[1,2,3],[4,5,6]]`, not in `[[1,3,5],[2,4,6]]` (Fortran-like order),
+        regardless of the memory layout of the input tensor. For C-contiguous
+        input, reshaping is cheap, for others it may require copying the data.
+    """
+
+    def __init__(self, incoming, shape):
+        super(ReshapeLayer, self).__init__(incoming)
+        shape = tuple(shape)
+        if not all(s is None or isinstance(s, int) for s in shape):
+            raise ValueError("`shape` must be a tuple of int and/or None")
+        if any(s is not None and (s == 0 or s < -1) for s in shape):
+            raise ValueError("`shape` integers must be positive or -1")
+        if sum(s == -1 for s in shape) > 1:
+            raise ValueError("`shape` cannot contain multiple -1")
+        self.shape = shape
+
+    def get_output_shape_for(self, input_shape, *args, **kwargs):
+        # First, replace all `None` with the corresponding input dimension
+        output_shape = list(self.shape)
+        for dim, o in enumerate(output_shape):
+            if o is None:
+                output_shape[dim] = input_shape[dim]
+        # Secondly, infer value for -1 if needed
+        if -1 in output_shape:
+            dim = output_shape.index(-1)
+            output_shape[dim] = np.prod(input_shape) // -np.prod(output_shape)
+        # Sanity check
+        if np.prod(input_shape) != np.prod(output_shape):
+            raise ValueError("%s cannot be reshaped to specification %s. "
+                             "The total size mismatches." %
+                             (input_shape, self.shape))
+        return tuple(output_shape)
+
+    def get_output_for(self, input, *args, **kwargs):
+        # Replace all `None` with the corresponding input dimension
+        output_shape = list(self.shape)
+        for dim, o in enumerate(output_shape):
+            if o is None:
+                output_shape[dim] = input.shape[dim]
+        # Everything else is handled by Theano
+        return input.reshape(tuple(output_shape))
 
 
 class PadLayer(Layer):

--- a/lasagne/layers/shape.py
+++ b/lasagne/layers/shape.py
@@ -11,6 +11,7 @@ __all__ = [
     "FlattenLayer",
     "flatten",
     "ReshapeLayer",
+    "reshape",
     "PadLayer",
     "pad",
 ]
@@ -133,6 +134,8 @@ class ReshapeLayer(Layer):
                 output_shape[dim] = input.shape[o[0]]
         # Everything else is handled by Theano
         return input.reshape(tuple(output_shape))
+
+reshape = ReshapeLayer # shortcut
 
 
 class PadLayer(Layer):

--- a/lasagne/layers/shape.py
+++ b/lasagne/layers/shape.py
@@ -89,6 +89,10 @@ class ReshapeLayer(Layer):
         masked_output_shape = list(output_shape)
         for dim, o in enumerate(output_shape):
             if isinstance(o, list):
+                if o[0] >= len(input_shape):
+                    raise ValueError("specification contains [%d], but input "
+                                     "shape has %d dimensions only" %
+                                     (o[0], len(input_shape)))
                 output_shape[dim] = input_shape[o[0]]
                 masked_output_shape[dim] = input_shape[o[0]]
                 if ((input_shape[o[0]] is None)

--- a/lasagne/tests/layers/test_shape.py
+++ b/lasagne/tests/layers/test_shape.py
@@ -1,0 +1,80 @@
+from mock import Mock
+import numpy
+import pytest
+import theano
+
+
+class TestReshapeLayer:
+    @pytest.fixture
+    def layerclass(self):
+        from lasagne.layers.shape import ReshapeLayer
+        return ReshapeLayer
+
+    @pytest.fixture
+    def two_unknown(self):
+        from lasagne.layers.input import InputLayer
+        shape = (16, 3, None, None, 10)
+        return (InputLayer(shape),
+                theano.shared(numpy.ones((16, 3, 5, 7, 10))))
+
+    def test_no_reference(self, layerclass, two_unknown):
+        inputlayer, inputdata = two_unknown
+        layer = layerclass(inputlayer, (16, 3, 5, 7, 2, 5))
+        assert layer.get_output_shape() == (16, 3, 5, 7, 2, 5)
+        result = layer.get_output_for(inputdata).eval()
+        assert result.shape == (16, 3, 5, 7, 2, 5)
+
+    def test_reference_both(self, layerclass, two_unknown):
+        inputlayer, inputdata = two_unknown
+        layer = layerclass(inputlayer, (-1, [1], [2], [3], 2, 5))
+        assert layer.get_output_shape() == (16, 3, None, None, 2, 5)
+        result = layer.get_output_for(inputdata).eval()
+        assert result.shape == (16, 3, 5, 7, 2, 5)
+
+    def test_reference_one(self, layerclass, two_unknown):
+        inputlayer, inputdata = two_unknown
+        layer = layerclass(inputlayer, (-1, [1], [2], 7, 2, 5))
+        assert layer.get_output_shape() == (None, 3, None, 7, 2, 5)
+        result = layer.get_output_for(inputdata).eval()
+        assert result.shape == (16, 3, 5, 7, 2, 5)
+
+    def test_reference_twice(self, layerclass, two_unknown):
+        inputlayer, inputdata = two_unknown
+        layer = layerclass(inputlayer, (-1, [1], [2], [3], 2, [2]))
+        assert layer.get_output_shape() == (None, 3, None, None, 2, None)
+        result = layer.get_output_for(inputdata).eval()
+        assert result.shape == (16, 3, 5, 7, 2, 5)
+
+    def test_merge_with_unknown(self, layerclass, two_unknown):
+        inputlayer, inputdata = two_unknown
+        layer = layerclass(inputlayer, ([0], [1], [2], -1))
+        assert layer.get_output_shape() == (16, 3, None, None)
+        result = layer.get_output_for(inputdata).eval()
+        assert result.shape == (16, 3, 5, 70)
+
+    def test_merge_two_unknowns(self, layerclass, two_unknown):
+        inputlayer, inputdata = two_unknown
+        layer = layerclass(inputlayer, ([0], [1], -1, [4]))
+        assert layer.get_output_shape() == (16, 3, None, 10)
+        result = layer.get_output_for(inputdata).eval()
+        assert result.shape == (16, 3, 35, 10)
+
+    def test_size_mismatch(self, layerclass, two_unknown):
+        inputlayer, inputdata = two_unknown
+        layer = layerclass(inputlayer, (17, 3, [2], [3], -1))
+        with pytest.raises(ValueError) as excinfo:
+            layer.get_output_shape() == (16, 3, None, 10)
+        assert 'match' in str(excinfo.value)
+
+    def test_invalid_spec(self, layerclass, two_unknown):
+        inputlayer, inputdata = two_unknown
+        with pytest.raises(ValueError):
+            layerclass(inputlayer, (-16, 3, 5, 7, 10))
+        with pytest.raises(ValueError):
+            layerclass(inputlayer, (-1, 3, 5, 7, -1))
+        with pytest.raises(ValueError):
+            layerclass(inputlayer, ([-1], 3, 5, 7, 10))
+        with pytest.raises(ValueError):
+            layerclass(inputlayer, ([0, 1], 3, 5, 7, 10))
+        with pytest.raises(ValueError):
+            layerclass(inputlayer, (None, 3, 5, 7, 10))

--- a/lasagne/tests/layers/test_shape.py
+++ b/lasagne/tests/layers/test_shape.py
@@ -78,3 +78,9 @@ class TestReshapeLayer:
             layerclass(inputlayer, ([0, 1], 3, 5, 7, 10))
         with pytest.raises(ValueError):
             layerclass(inputlayer, (None, 3, 5, 7, 10))
+
+    def test_reference_out_of_range(self, layerclass, two_unknown):
+        inputlayer, inputdata = two_unknown
+        layer = layerclass(inputlayer, (16, 3, 5, 7, [5]))
+        with pytest.raises(ValueError):
+            layer.get_output_for(inputdata)


### PR DESCRIPTION
This adds `layers.ReshapeLayer`.

In addition to supporting fixed shapes and shapes with `-1` for one dimension to be inferred automatically, it also supports `None` for dimensions to be copied from the input shape. This should be handy especially for the batch size, so you can keep the batch size constant even if you don't know its value and still have the `-1` available for automatically inferring any of the other dimensions. (Only works if the batch size is the first dimension, though.)

If you're fine with the proposed interface and functionality, I'll add tests. If you have any ingenious idea on how to improve the "copy dimensions" feature, let me know.