### PR TITLE
Add a few conv2d layer tests

### DIFF
--- a/examples/mnist_conv_dnn.py
+++ b/examples/mnist_conv_dnn.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import lasagne
+from lasagne.layers import dnn  # fails early if not available
 import theano
 import theano.tensor as T
 

--- a/lasagne/conftest.py
+++ b/lasagne/conftest.py
@@ -1,0 +1,12 @@
+ignore_test_paths = [
+    "*/layers/corrmm.py",
+    "*/layers/cuda_convnet.py",
+    "*/layers/dnn.py",
+    ]
+
+
+def pytest_ignore_collect(path, config):
+    """Ignore paths that would otherwise be collceted by the doctest
+    plugin and lead to ImportError due to missing dependencies.
+    """
+    return any(path.fnmatch(ignore) for ignore in ignore_test_paths)

--- a/lasagne/layers/__init__.py
+++ b/lasagne/layers/__init__.py
@@ -7,6 +7,14 @@ from .conv import *
 from .pool import *
 from .shape import *
 from .merge import *
-from .cuda_convnet import *
 from .corrmm import *
-from .dnn import *
+
+try:
+    from .cuda_convnet import *
+except ImportError:
+    pass
+
+try:
+    from .dnn import *
+except ImportError:
+    pass

--- a/lasagne/layers/__init__.py
+++ b/lasagne/layers/__init__.py
@@ -7,7 +7,11 @@ from .conv import *
 from .pool import *
 from .shape import *
 from .merge import *
-from .corrmm import *
+
+try:
+    from .corrmm import *
+except ImportError:
+    pass
 
 try:
     from .cuda_convnet import *

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -21,6 +21,10 @@ __all__ = [
 ]
 
 
+if not theano.config.device.startswith("gpu"):
+    raise ImportError("requires a GPU to work")
+
+
 # base class for all layers that rely on GpuCorrMM directly
 class MMLayer(Layer):
     pass

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -23,6 +23,10 @@ __all__ = [
 ]
 
 
+if not theano.config.device.startswith("gpu"):
+    raise ImportError("requires a GPU to work")
+
+
 # TODO: make sure to document the limitations and 'best practices' (i.e. minibatch size % 128 == 0)
 # TODO: see if the 'dimshuffle' logic can be put in the base class instead.
 

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -8,6 +8,7 @@ from .. import nonlinearities
 from .base import Layer
 
 from theano.sandbox.cuda.basic_ops import gpu_contiguous
+from pylearn2.sandbox.cuda_convnet.filter_acts import FilterActs
 
 
 __all__ = [
@@ -35,8 +36,6 @@ class Conv2DCCLayer(CCLayer):
     def __init__(self, input_layer, num_filters, filter_size, strides=(1, 1), border_mode=None, untie_biases=False,
                  W=init.Uniform(), b=init.Constant(0.), nonlinearity=nonlinearities.rectify, pad=None,
                  dimshuffle=True, flip_filters=False, partial_sum=1):
-        from pylearn2.sandbox.cuda_convnet.filter_acts import FilterActs
-
         super(Conv2DCCLayer, self).__init__(input_layer)
         if nonlinearity is None:
             self.nonlinearity = nonlinearities.identity

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -38,8 +38,6 @@ class Pool2DDNNLayer(DNNLayer):
         return tuple(output_shape)
 
     def get_output_for(self, input, *args, **kwargs):
-        if not dnn_available:
-            raise RuntimeError("cudnn is not available.")
         return dnn.dnn_pool(input, self.ds, self.strides, self.mode)
 
 
@@ -117,8 +115,6 @@ class Conv2DDNNLayer(DNNLayer):
         return (batch_size, self.num_filters, output_rows, output_columns)
 
     def get_output_for(self, input, *args, **kwargs):
-        if not dnn_available:
-            raise RuntimeError('cudnn is not available.')
         # by default we assume 'cross', consistent with corrmm.
         conv_mode = 'conv' if self.flip_filters else 'cross'
         # if 'border_mode' is one of 'valid' or 'full' use that.

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -1,5 +1,6 @@
 import numpy as np
 import theano
+from theano.sandbox.cuda import dnn
 import theano.tensor as T
 
 from .. import init
@@ -8,12 +9,8 @@ from .. import nonlinearities
 from .base import Layer
 
 
-dnn_available = False
-
-if theano.config.device.startswith("gpu"):
-    from theano.sandbox.cuda import dnn
-    if dnn.dnn_available():
-        dnn_available = True
+if not theano.config.device.startswith("gpu") or not dnn.dnn_available():
+    raise ImportError("dnn not available")
 
 
 __all__ = [

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -1,80 +1,25 @@
 from mock import Mock
 import numpy as np
 import pytest
+import theano
+from theano.tensor.nnet import conv2d
 
 from lasagne.utils import floatX
 
 
-def input_kernel_and_output_one_sample():
-    input = np.array([[[
-        [1, 1, 1, 0, 0],
-        [0, 1, 1, 1, 0],
-        [0, 0, 1, 1, 1],
-        [0, 0, 1, 1, 0],
-        [0, 1, 1, 0, 0],
-        ]]])
-    kernel = np.array([[[
-        [1, 0, 1],
-        [0, 1, 0],
-        [1, 0, 1],
-        ]]])
-    output = np.array([[[
-        [4, 3, 4],
-        [2, 4, 3],
-        [2, 3, 4],
-        ]]])
-    return map(floatX, [input, kernel, output])
+def conv2d_test_sets():
+    def _convert(input, kernel, output, kwargs):
+        return [theano.shared(floatX(input)), floatX(kernel), output, kwargs]
 
+    input = np.random.random((3, 1, 16, 16))
+    kernel = np.random.random((16, 1, 3, 3))
+    output = conv2d(input, kernel).eval()
+    yield _convert(input, kernel, output, {})
 
-def input_kernel_and_output_multiple_samples():
-    input, kernel, output = input_kernel_and_output_one_sample()
-
-    input = np.repeat(input, 5, axis=0)
-    output = np.repeat(output, 5, axis=0)
-
-    return map(floatX, [input, kernel, output])
-
-
-def input_kernel_and_output_multiple_filters():
-    input, kernel, output = input_kernel_and_output_one_sample()
-
-    kernel = np.array([
-        [[
-            [1, 0, 1],
-            [0, 1, 0],
-            [1, 0, 1],
-        ]],
-        [[
-            [0, 0, 0],
-            [1, 1, 1],
-            [0, 0, 0],
-        ]],
-    ])
-
-    output = np.array([[
-        [
-            [4, 3, 4],
-            [2, 4, 3],
-            [2, 3, 4],
-        ],
-        [
-            [2, 3, 2],
-            [1, 2, 3],
-            [1, 2, 2],
-        ],
-        ]])
-
-    return map(floatX, [input, kernel, output])
-
-
-def input_kernel_and_output_multiple_channels():
-    input, kernel, output = input_kernel_and_output_multiple_filters()
-
-    # all the inputs channels are identical:
-    input = np.repeat(input, 2, axis=1)
-    kernel = kernel.transpose(1, 0, 2, 3)
-    output = output.sum(axis=1)[None, :]
-    return map(floatX, [input, kernel, output])
+    input = np.random.random((3, 3, 16, 16))
+    kernel = np.random.random((16, 3, 3, 3))
+    output = conv2d(input, kernel).eval()
+    yield _convert(input, kernel, output, {})
 
 
 @pytest.fixture
@@ -90,31 +35,38 @@ def DummyInputLayer():
 class TestConv2DLayerImplementations:
     @pytest.fixture(
         params=[
-            "Conv2DLayer",
-            "Conv2DMMLayer",
-            "Conv2DDNNLayer",  # untested
+            ('Conv2DLayer', {}),
+            ('Conv2DCCLayer', {'flip_filters': True}),
+            ('Conv2DMMLayer', {'flip_filters': True}),
+            ('Conv2DDNNLayer', {'flip_filters': True}),
             ],
         )
     def Conv2DImpl(self, request):
         from lasagne import layers
+        impl_name, impl_default_kwargs = request.param
         try:
-            return getattr(layers, request.param)
+            impl = getattr(layers, impl_name)
         except AttributeError:
             pytest.skip("{} not available".format(request.param))
 
-    @pytest.mark.parametrize("input, kernel, output", [
-        input_kernel_and_output_one_sample(),
-        input_kernel_and_output_multiple_samples(),
-        input_kernel_and_output_multiple_filters(),
-        input_kernel_and_output_multiple_channels(),
-        ])
-    @pytest.mark.parametrize("kwargs", [
+        def wrapper(*args, **kwargs):
+            kwargs2 = impl_default_kwargs.copy()
+            kwargs2.update(kwargs)
+            return impl(*args, **kwargs2)
+
+        wrapper.__name__ = impl_name
+        return wrapper
+
+    @pytest.mark.parametrize(
+        "input, kernel, output, kwargs", list(conv2d_test_sets()))
+    @pytest.mark.parametrize("extra_kwargs", [
         {},
         {'untie_biases': True},
         ])
     def test_defaults(self, Conv2DImpl, DummyInputLayer,
-                      input, kernel, output, kwargs):
-        input_layer = DummyInputLayer(input.shape)
+                      input, kernel, output, kwargs, extra_kwargs):
+        kwargs.update(extra_kwargs)
+        input_layer = DummyInputLayer(input.shape.eval())
         layer = Conv2DImpl(
             input_layer,
             num_filters=kernel.shape[0],
@@ -124,4 +76,4 @@ class TestConv2DLayerImplementations:
             )
         actual = layer.get_output(input).eval()
         assert actual.shape == output.shape
-        assert (actual == output).all()
+        assert np.allclose(actual, output)

--- a/lasagne/tests/layers/test_conv.py
+++ b/lasagne/tests/layers/test_conv.py
@@ -1,0 +1,127 @@
+from mock import Mock
+import numpy as np
+import pytest
+
+from lasagne.utils import floatX
+
+
+def input_kernel_and_output_one_sample():
+    input = np.array([[[
+        [1, 1, 1, 0, 0],
+        [0, 1, 1, 1, 0],
+        [0, 0, 1, 1, 1],
+        [0, 0, 1, 1, 0],
+        [0, 1, 1, 0, 0],
+        ]]])
+    kernel = np.array([[[
+        [1, 0, 1],
+        [0, 1, 0],
+        [1, 0, 1],
+        ]]])
+    output = np.array([[[
+        [4, 3, 4],
+        [2, 4, 3],
+        [2, 3, 4],
+        ]]])
+    return map(floatX, [input, kernel, output])
+
+
+def input_kernel_and_output_multiple_samples():
+    input, kernel, output = input_kernel_and_output_one_sample()
+
+    input = np.repeat(input, 5, axis=0)
+    output = np.repeat(output, 5, axis=0)
+
+    return map(floatX, [input, kernel, output])
+
+
+def input_kernel_and_output_multiple_filters():
+    input, kernel, output = input_kernel_and_output_one_sample()
+
+    kernel = np.array([
+        [[
+            [1, 0, 1],
+            [0, 1, 0],
+            [1, 0, 1],
+        ]],
+        [[
+            [0, 0, 0],
+            [1, 1, 1],
+            [0, 0, 0],
+        ]],
+    ])
+
+    output = np.array([[
+        [
+            [4, 3, 4],
+            [2, 4, 3],
+            [2, 3, 4],
+        ],
+        [
+            [2, 3, 2],
+            [1, 2, 3],
+            [1, 2, 2],
+        ],
+        ]])
+
+    return map(floatX, [input, kernel, output])
+
+
+def input_kernel_and_output_multiple_channels():
+    input, kernel, output = input_kernel_and_output_multiple_filters()
+
+    # all the inputs channels are identical:
+    input = np.repeat(input, 2, axis=1)
+    kernel = kernel.transpose(1, 0, 2, 3)
+    output = output.sum(axis=1)[None, :]
+    return map(floatX, [input, kernel, output])
+
+
+@pytest.fixture
+def DummyInputLayer():
+    def factory(get_output_shape):
+        return Mock(
+            get_output_shape=lambda: get_output_shape,
+            get_output=lambda input: input,
+            )
+    return factory
+
+
+class TestConv2DLayerImplementations:
+    @pytest.fixture(
+        params=[
+            "Conv2DLayer",
+            "Conv2DMMLayer",
+            "Conv2DDNNLayer",  # untested
+            ],
+        )
+    def Conv2DImpl(self, request):
+        from lasagne import layers
+        try:
+            return getattr(layers, request.param)
+        except AttributeError:
+            pytest.skip("{} not available".format(request.param))
+
+    @pytest.mark.parametrize("input, kernel, output", [
+        input_kernel_and_output_one_sample(),
+        input_kernel_and_output_multiple_samples(),
+        input_kernel_and_output_multiple_filters(),
+        input_kernel_and_output_multiple_channels(),
+        ])
+    @pytest.mark.parametrize("kwargs", [
+        {},
+        {'untie_biases': True},
+        ])
+    def test_defaults(self, Conv2DImpl, DummyInputLayer,
+                      input, kernel, output, kwargs):
+        input_layer = DummyInputLayer(input.shape)
+        layer = Conv2DImpl(
+            input_layer,
+            num_filters=kernel.shape[0],
+            filter_size=kernel.shape[2:],
+            W=kernel,
+            **kwargs
+            )
+        actual = layer.get_output(input).eval()
+        assert actual.shape == output.shape
+        assert (actual == output).all()

--- a/lasagne/tests/test_examples.py
+++ b/lasagne/tests/test_examples.py
@@ -29,7 +29,8 @@ def test_example(example, module_name):
     try:
         main = getattr(import_module(module_name), 'main')
     except ImportError as e:
-        if "pylearn2" in str(e) or "dnn not available" in str(e):
+        skip_exceptions = ["requires a GPU", "pylearn2", "dnn not available"]
+        if any([text in str(e) for text in skip_exceptions]):
             pytest.skip(e)
         else:
             raise

--- a/lasagne/tests/test_examples.py
+++ b/lasagne/tests/test_examples.py
@@ -28,14 +28,10 @@ def example(request):
 def test_example(example, module_name):
     try:
         main = getattr(import_module(module_name), 'main')
-        main(1)  # run the example for one iteration
-    except ImportError as e:  # some examples require pylearn2
-        if "pylearn2" in str(e):
+    except ImportError as e:
+        if "pylearn2" in str(e) or "dnn not available" in str(e):
             pytest.skip(e)
         else:
             raise
-    except RuntimeError as e: # ignore errors caused by cudnn absence
-        if "cudnn is not available" in str(e):
-            pytest.skip(e)
-        else:
-            raise
+
+    main(1)  # run the example for one iteration

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/Theano/Theano.git@647921d7d26f4a848f023d5c7ef6329f4dfb5563#egg=Theano
+-e git+https://github.com/Theano/Theano.git@b84464261ffa1d451097ac5e5243dcd8f7e0ff62#egg=Theano

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,5 +6,5 @@ docs = develop easy_install lasagne[docs]
 addopts =
     -v --doctest-modules
     --cov=lasagne --cov-report=term-missing
-    lasagne/
+    lasagne/tests/
 python_files = test*py

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,5 +6,5 @@ docs = develop easy_install lasagne[docs]
 addopts =
     -v --doctest-modules
     --cov=lasagne --cov-report=term-missing
-    lasagne/tests/
+    lasagne/
 python_files = test*py


### PR DESCRIPTION
test_conv.py tests three conv 2d layer implementations using mostly
default parameters.  

The tests run convolutions with small kernels on small inputs.  (Which
is why it doesn't work with cuda-convnet.)  The convolution math was
done by hand, to allow checking actual outputs against expected
outputs.

The tests so far did turn out a bit hairy, maybe hard to follow.
Also, there's no way a few generic tests like this one could cover all
the special cases between the different implementations.  But it does
maybe cover a lot of common ground between them.  Interested to hear
what people think.

A part of this pull request changes the way that modules with missing
dependencies are dealt with, particurly lasagne.layers.dnn and
lasagne.layers.cuda_convnet.

Previously, these two modules failed at runtime, when we were running
their code.  This is changed herein; these modules will now fail with
ImportError when using from-imports, like these:

  - from lasagne.layers import Conv2DDNNLayer
  - from lasagne.layers.dnn import Conv2DDNNLayer

Unforunately, accessing the module contents using attribute-style
module traversal, like in 'Layer = lasagne.layers.Conv2DDNNLayer',
will result in AttributeError, without an error message.  (This might
be controversial.)

The upshot is that with this we now have a consistent way to know
whether or not a particular module has unsatisfied dependencies,
without having to run the actual code.  This is something I really
want to be able to do to conditionally to run tests against different
implementations based on availability.  Not sure there's a better way
to deal with this.
