### PR TITLE
removed automatic import of modules with GPU-related dependencies.

### DIFF
--- a/lasagne/layers/__init__.py
+++ b/lasagne/layers/__init__.py
@@ -7,18 +7,3 @@ from .conv import *
 from .pool import *
 from .shape import *
 from .merge import *
-
-try:
-    from .corrmm import *
-except ImportError:
-    pass
-
-try:
-    from .cuda_convnet import *
-except ImportError:
-    pass
-
-try:
-    from .dnn import *
-except ImportError:
-    pass


### PR DESCRIPTION
also updated convolution implementation tests to match. @dnouri does this look okay? You wrote the tests originally so I guess you should have a look.