### PR TITLE
Preventing None from appearing in get_all_layers' returned list

### DIFF
--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -60,7 +60,9 @@ def get_all_layers(layer):
             children = [current_layer.input_layer]
 
         # filter the layers that have already been visited.
-        children = [child for child in children if child not in layers]
+        children = [child for child in children
+                    if child not in layers
+                    and child is not None]
         layers_to_expand.extend(children)
         layers.extend(children)
 

--- a/lasagne/layers/helper.py
+++ b/lasagne/layers/helper.py
@@ -59,7 +59,8 @@ def get_all_layers(layer):
         elif hasattr(current_layer, 'input_layer'):
             children = [current_layer.input_layer]
 
-        # filter the layers that have already been visited.
+        # filter the layers that have already been visited, and remove None
+        # elements (for layers without incoming layers)
         children = [child for child in children
                     if child not in layers
                     and child is not None]


### PR DESCRIPTION
This should fix the issue I mentioned here:
https://github.com/benanne/Lasagne/pull/52#issuecomment-72264767
I.e., now that a layer can have an input attribute which is `None`, `get_all_layers` can return a list which has entries which are `None`.  This causes problems, e.g. causes `get_all_params` to fail because 
```Python
    layers = get_all_layers(layer)
    params = sum([l.get_params() for l in layers], [])
```
I'm not 100% sure this is the best way/only place to fix this, but I think it is.