### PR TITLE
Objectives now have an optional mask.

### DIFF
--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -106,11 +106,11 @@ def create_iter_functions(dataset, output_layer,
     batch_slice = slice(
         batch_index * batch_size, (batch_index + 1) * batch_size)
 
-    objective = lasagne.objectives.Objective(
-        output_layer, loss_function=lasagne.objectives.multinomial_nll)
+    objective = lasagne.objectives.Objective(output_layer,
+        loss_function=lasagne.objectives.categorical_crossentropy)
 
     loss_train = objective.get_loss(X_batch, target=y_batch)
-    loss_eval = objective.get_loss(X_batch, target=y_batch, deterministic=True)
+    loss_eval = objective.get_loss(X_batch, target=y_batch,deterministic=True)
 
     pred = T.argmax(
         output_layer.get_output(X_batch, deterministic=True), axis=1)

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -110,7 +110,8 @@ def create_iter_functions(dataset, output_layer,
         loss_function=lasagne.objectives.categorical_crossentropy)
 
     loss_train = objective.get_loss(X_batch, target=y_batch)
-    loss_eval = objective.get_loss(X_batch, target=y_batch,deterministic=True)
+    loss_eval = objective.get_loss(X_batch, target=y_batch,
+                                   deterministic=True)
 
     pred = T.argmax(
         output_layer.get_output(X_batch, deterministic=True), axis=1)

--- a/lasagne/objectives.py
+++ b/lasagne/objectives.py
@@ -181,6 +181,6 @@ class MaskedObjective(object):
             normalize_mask = self.normalize_mask
 
         if normalize_mask:
-            mask = mask / T.cast(1.0 / T.sum(mask), theano.config.floatX)
+            mask = mask / T.sum(mask)
 
         return self.loss_function(network_output, target, mask)

--- a/lasagne/objectives.py
+++ b/lasagne/objectives.py
@@ -1,35 +1,50 @@
+import theano
 import theano.tensor as T
 
 
-def mse(x, t):
+def mse(x, t, m):
     """Calculates the MSE mean across all dimensions, i.e. feature
      dimension AND minibatch dimension.
 
     :parameters:
         - x : predicted values
         - t : target values
+        - m : mask; None for no mask, or a 1-dimensional array, that
+            selects which rows in `x` and `t` should count towards the
+            result
 
     :returns:
         - output : the mean square error across all dimensions
     """
-    return T.mean((x - t) ** 2)
+    if m is None:
+        return T.mean((x - t) ** 2)
+    else:
+        recip_mask_sum = T.cast(1.0 / T.sum(m), theano.config.floatX)
+        return T.sum(m * (x - t) ** 2) * recip_mask_sum
 
 
-def crossentropy(x, t):
+def crossentropy(x, t, m):
     """Calculates the binary crossentropy mean across all dimentions,
     i.e.  feature dimension AND minibatch dimension.
 
     :parameters:
         - x : predicted values
         - t : target values
+        - m : mask; None for no mask, or a 1-dimensional array, that
+            selects which rows in `x` and `t` should count towards the
+            result
 
     :returns:
         - output : the mean binary cross entropy across all dimensions
     """
-    return T.mean(T.nnet.binary_crossentropy(x, t))
+    if m is None:
+        return T.mean(T.nnet.binary_crossentropy(x, t))
+    else:
+        recip_mask_sum = T.cast(1.0 / T.sum(m), theano.config.floatX)
+        return T.sum(T.nnet.binary_crossentropy(x, t)) * recip_mask_sum
 
 
-def multinomial_nll(x, t):
+def multinomial_nll(x, t, m):
     """Calculates the mean multinomial negative-log-loss
 
     :parameters:
@@ -41,11 +56,21 @@ def multinomial_nll(x, t):
             a 1D integer array that gives the class index of each sample
             (the position of the 1 in the row in a 1-of-N encoding, or
             1-hot encoding),
+        - m : mask; None for no mask, or a 1-dimensional array, that
+            selects which rows in `x` and `t` should count towards the
+            result
 
     :returns:
         - output : the mean multinomial negative log loss
     """
-    return T.mean(T.nnet.categorical_crossentropy(x, t))
+    if m is None:
+        return -T.mean(T.log(x)[T.arange(t.shape[0]), t])
+    else:
+        recip_mask_sum = T.cast(1.0 / T.sum(m), theano.config.floatX)
+        masked_nll_sum = T.sum(T.log(x)[T.arange(t.shape[0]), t] * m)
+        return -masked_nll_sum * recip_mask_sum
+
+
 
 
 class Objective(object):
@@ -69,8 +94,9 @@ class Objective(object):
         self.input_layer = input_layer
         self.loss_function = loss_function
         self.target_var = T.matrix("target")
+        self.mask_var = None
 
-    def get_loss(self, input=None, target=None, *args, **kwargs):
+    def get_loss(self, input=None, target=None, mask=None, *args, **kwargs):
         """
         Get loss scalar expression
 
@@ -80,6 +106,10 @@ class Objective(object):
             - target : (default `None`) an expression that results in the
                 desired output that the network is being trained to generate
                 given the input
+            - mask : (default `None`) [optional] an expression that results in
+                a mask. Zero values in the mask will prevent the values in
+                the corresponding rows in `input` and `target` from counting
+                toward the loss value that is returned
             - args : additional arguments passed to `input_layer`'s
                 `get_output` method
             - kwargs : additional keyword arguments passed to `input_layer`'s
@@ -91,5 +121,7 @@ class Objective(object):
         network_output = self.input_layer.get_output(input, *args, **kwargs)
         if target is None:
             target = self.target_var
+        if mask is None:
+            mask = self.mask_var
 
-        return self.loss_function(network_output, target)
+        return self.loss_function(network_output, target, mask)

--- a/lasagne/objectives.py
+++ b/lasagne/objectives.py
@@ -17,8 +17,6 @@ def mse(x, t):
     return (x - t) ** 2
 
 
-
-
 class Objective(object):
     _valid_aggregation = {None, 'mean', 'sum'}
 
@@ -48,12 +46,12 @@ class Objective(object):
         self.loss_function = loss_function
         self.target_var = T.matrix("target")
         if aggregation not in self._valid_aggregation:
-            raise ValueError('aggregation must be \'mean\', \'sum\', ' \
-                'or None, not {0}'.format(aggregation))
+            raise ValueError('aggregation must be \'mean\', \'sum\', '
+                             'or None, not {0}'.format(aggregation))
         self.aggregation = aggregation
 
-
-    def get_loss(self, input=None, target=None, aggregation=None, *args, **kwargs):
+    def get_loss(self, input=None, target=None, aggregation=None,
+                 *args, **kwargs):
         """
         Get loss scalar expression
 
@@ -75,22 +73,19 @@ class Objective(object):
         if target is None:
             target = self.target_var
         if aggregation not in self._valid_aggregation:
-            raise ValueError('aggregation must be \'mean\', \'sum\', ' \
-                'or None, not {0}'.format(aggregation))
+            raise ValueError('aggregation must be \'mean\', \'sum\', '
+                             'or None, not {0}'.format(aggregation))
         if aggregation is None:
             aggregation = self.aggregation
 
         losses = self.loss_function(network_output, target)
 
-        if aggregation is None  or  aggregation == 'mean':
+        if aggregation is None or aggregation == 'mean':
             return losses.mean()
         elif aggregation == 'sum':
             return losses.sum()
         else:
             raise RuntimeError('This should have been caught earlier')
-
-
-
 
 
 class MaskedObjective(object):
@@ -127,8 +122,9 @@ class MaskedObjective(object):
         self.target_var = T.matrix("target")
         self.mask_var = T.matrix("mask")
         if aggregation not in self._valid_aggregation:
-            raise ValueError('aggregation must be \'mean\', \'sum\', ' \
-                '\'normalized_sum\' or None, not {0}'.format(aggregation))
+            raise ValueError('aggregation must be \'mean\', \'sum\', '
+                             '\'normalized_sum\' or None,'
+                             ' not {0}'.format(aggregation))
         self.aggregation = aggregation
 
     def get_loss(self, input=None, target=None, mask=None,
@@ -163,8 +159,9 @@ class MaskedObjective(object):
             mask = self.mask_var
 
         if aggregation not in self._valid_aggregation:
-            raise ValueError('aggregation must be \'mean\', \'sum\', ' \
-                '\'normalized_sum\' or None, not {0}'.format(aggregation))
+            raise ValueError('aggregation must be \'mean\', \'sum\', '
+                             '\'normalized_sum\' or None, '
+                             'not {0}'.format(aggregation))
 
         # Get aggregation value passed to constructor if None
         if aggregation is None:
@@ -172,7 +169,7 @@ class MaskedObjective(object):
 
         masked_losses = self.loss_function(network_output, target) * mask
 
-        if aggregation is None  or  aggregation == 'mean':
+        if aggregation is None or aggregation == 'mean':
             return masked_losses.mean()
         elif aggregation == 'sum':
             return masked_losses.sum()

--- a/lasagne/objectives.py
+++ b/lasagne/objectives.py
@@ -2,16 +2,15 @@ import theano
 import theano.tensor as T
 
 
-def mse(x, t, m):
+def mse(x, t, m=None):
     """Calculates the MSE mean across all dimensions, i.e. feature
      dimension AND minibatch dimension.
 
     :parameters:
         - x : predicted values
         - t : target values
-        - m : mask; None for no mask, or a 1-dimensional array, that
-            selects which rows in `x` and `t` should count towards the
-            result
+        - m : mask; None for no mask, or an array the same shape as `t`
+            that selects/weights the contribution of elements in `x` and `t`
 
     :returns:
         - output : the mean square error across all dimensions
@@ -19,20 +18,18 @@ def mse(x, t, m):
     if m is None:
         return T.mean((x - t) ** 2)
     else:
-        recip_mask_sum = T.cast(1.0 / T.sum(m), theano.config.floatX)
-        return T.sum(m * (x - t) ** 2) * recip_mask_sum
+        return T.sum(((x - t) ** 2) * m)
 
 
-def crossentropy(x, t, m):
+def crossentropy(x, t, m=None):
     """Calculates the binary crossentropy mean across all dimentions,
     i.e.  feature dimension AND minibatch dimension.
 
     :parameters:
         - x : predicted values
         - t : target values
-        - m : mask; None for no mask, or a 1-dimensional array, that
-            selects which rows in `x` and `t` should count towards the
-            result
+        - m : mask; None for no mask, or an array the same shape as `t`
+            that selects/weights the contribution of elements in `x` and `t`
 
     :returns:
         - output : the mean binary cross entropy across all dimensions
@@ -40,35 +37,34 @@ def crossentropy(x, t, m):
     if m is None:
         return T.mean(T.nnet.binary_crossentropy(x, t))
     else:
-        recip_mask_sum = T.cast(1.0 / T.sum(m), theano.config.floatX)
-        return T.sum(T.nnet.binary_crossentropy(x, t)) * recip_mask_sum
+        return T.sum(T.nnet.binary_crossentropy(x, t) * m)
 
 
-def multinomial_nll(x, t, m):
+def multinomial_nll(x, t, m=None):
     """Calculates the mean multinomial negative-log-loss
 
     :parameters:
         - x : (predicted) class probabilities; a theano expression resulting
-            in a 2D array; samples run along axis 0, class probabilities along
-            axis 1
+            in a 2D array; samples run along axis 0, class probabilities
+            along axis 1
         - t : (correct) class probabilities; a theano expression resulting in
             a 2D tensor that gives the class probabilities in its rows, OR
             a 1D integer array that gives the class index of each sample
             (the position of the 1 in the row in a 1-of-N encoding, or
             1-hot encoding),
-        - m : mask; None for no mask, or a 1-dimensional array, that
-            selects which rows in `x` and `t` should count towards the
-            result
+        - m : mask; None for no mask, or a 1D array that selects/weights
+            the contributions of the log-loss scores of each sample before
+            they are summed
 
     :returns:
         - output : the mean multinomial negative log loss
     """
     if m is None:
-        return -T.mean(T.log(x)[T.arange(t.shape[0]), t])
+        return T.mean(T.nnet.categorical_crossentropy(x, t))
     else:
-        recip_mask_sum = T.cast(1.0 / T.sum(m), theano.config.floatX)
-        masked_nll_sum = T.sum(T.log(x)[T.arange(t.shape[0]), t] * m)
-        return -masked_nll_sum * recip_mask_sum
+        if m.ndim != 1:
+            raise ValueError, 'mask must be a 1D array'
+        return T.sum(T.nnet.categorical_crossentropy(x, t) * m)
 
 
 
@@ -77,8 +73,8 @@ class Objective(object):
     """
     Training objective
 
-    The  `get_loss` method returns an expression that can be used for training
-    with a gradient descent approach.
+    The  `get_loss` method returns an expression that can be used for
+    training with a gradient descent approach.
     """
     def __init__(self, input_layer, loss_function=mse):
         """
@@ -94,22 +90,79 @@ class Objective(object):
         self.input_layer = input_layer
         self.loss_function = loss_function
         self.target_var = T.matrix("target")
-        self.mask_var = None
 
-    def get_loss(self, input=None, target=None, mask=None, *args, **kwargs):
+
+    def get_loss(self, input=None, target=None, *args, **kwargs):
         """
         Get loss scalar expression
 
         :parameters:
-            - input : (default `None`) an expression that results in the input
-                data that is passed to the network
+            - input : (default `None`) an expression that results in the
+                input data that is passed to the network
             - target : (default `None`) an expression that results in the
                 desired output that the network is being trained to generate
                 given the input
-            - mask : (default `None`) [optional] an expression that results in
-                a mask. Zero values in the mask will prevent the values in
-                the corresponding rows in `input` and `target` from counting
-                toward the loss value that is returned
+            - args : additional arguments passed to `input_layer`'s
+                `get_output` method
+            - kwargs : additional keyword arguments passed to `input_layer`'s
+                `get_output` method
+
+        :returns:
+            - output : loss expressions
+        """
+        network_output = self.input_layer.get_output(input, *args, **kwargs)
+        if target is None:
+            target = self.target_var
+
+        return self.loss_function(network_output, target)
+
+
+
+
+
+class MaskedObjective(object):
+    """
+    Masked training objective
+
+    The  `get_loss` method returns an expression that can be used for
+    training with a gradient descent approach, with masking applied to weight
+    the contribution of samples to the final loss.
+    """
+    def __init__(self, input_layer, loss_function=mse, normalize_mask=False):
+        """
+        Constructor
+
+        :parameters:
+            - input_layer : a `Layer` whose output is the networks prediction
+                given its input
+            - loss_function : a loss function of the form `f(x, t, m)` that
+                returns a scalar loss given tensors that represent the
+                predicted values, true values and mask as arguments.
+        """
+        self.input_layer = input_layer
+        self.loss_function = loss_function
+        self.target_var = T.matrix("target")
+        self.mask_var = T.matrix("mask")
+        self.normalize_mask = normalize_mask
+
+    def get_loss(self, input=None, target=None, mask=None,
+                 normalize_mask=None, *args, **kwargs):
+        """
+        Get loss scalar expression
+
+        :parameters:
+            - input : (default `None`) an expression that results in the
+                input data that is passed to the network
+            - target : (default `None`) an expression that results in the
+                desired output that the network is being trained to generate
+                given the input
+            - mask : None for no mask, or a mask that is the same shape
+                as `target`/`self.target_var` - or will broadcast to that
+                shape - that selects/weights the contributions of
+                the samples to the final loss
+            - normalize_mask : None to use the value passed to the
+                constructor, or a bool to override it. If True, the mask will
+                be normalized by dividing it by its sum before being applied.
             - args : additional arguments passed to `input_layer`'s
                 `get_output` method
             - kwargs : additional keyword arguments passed to `input_layer`'s
@@ -123,5 +176,11 @@ class Objective(object):
             target = self.target_var
         if mask is None:
             mask = self.mask_var
+
+        if normalize_mask is None:
+            normalize_mask = self.normalize_mask
+
+        if normalize_mask:
+            mask = mask / T.cast(1.0 / T.sum(mask), theano.config.floatX)
 
         return self.loss_function(network_output, target, mask)

--- a/lasagne/objectives.py
+++ b/lasagne/objectives.py
@@ -23,8 +23,8 @@ class Objective(object):
     """
     Training objective
 
-    The  `get_loss` method returns an expression that can be used for
-    training with a gradient descent approach.
+    The  `get_loss` method returns cost expression useful for training or
+    evaluating a network.
     """
     def __init__(self, input_layer, loss_function=mse, aggregation='mean'):
         """
@@ -61,6 +61,8 @@ class Objective(object):
             - target : (default `None`) an expression that results in the
                 desired output that the network is being trained to generate
                 given the input
+            - aggregation : None to use the value passed to the
+                constructor or a value to override it
             - args : additional arguments passed to `input_layer`'s
                 `get_output` method
             - kwargs : additional keyword arguments passed to `input_layer`'s

--- a/lasagne/objectives.py
+++ b/lasagne/objectives.py
@@ -1,5 +1,6 @@
 import theano
 import theano.tensor as T
+from theano.tensor.nnet import binary_crossentropy, categorical_crossentropy
 
 
 def mse(x, t):
@@ -14,39 +15,6 @@ def mse(x, t):
         - output : the mean square error across all dimensions
     """
     return (x - t) ** 2
-
-
-def crossentropy(x, t):
-    """Calculates the binary crossentropy mean across all dimentions,
-    i.e.  feature dimension AND minibatch dimension.
-
-    :parameters:
-        - x : predicted values
-        - t : target values
-
-    :returns:
-        - output : the mean binary cross entropy across all dimensions
-    """
-    return T.nnet.binary_crossentropy(x, t)
-
-
-def multinomial_nll(x, t):
-    """Calculates the mean multinomial negative-log-loss
-
-    :parameters:
-        - x : (predicted) class probabilities; a theano expression resulting
-            in a 2D array; samples run along axis 0, class probabilities
-            along axis 1
-        - t : (correct) class probabilities; a theano expression resulting in
-            a 2D tensor that gives the class probabilities in its rows, OR
-            a 1D integer array that gives the class index of each sample
-            (the position of the 1 in the row in a 1-of-N encoding, or
-            1-hot encoding),
-
-    :returns:
-        - output : the mean multinomial negative log loss
-    """
-    return T.nnet.categorical_crossentropy(x, t)
 
 
 

--- a/lasagne/objectives.py
+++ b/lasagne/objectives.py
@@ -96,7 +96,7 @@ class Objective(object):
         if target is None:
             target = self.target_var
 
-        return T.mean(self.loss_function(network_output, target))
+        return self.loss_function(network_output, target).mean()
 
 
 
@@ -164,6 +164,6 @@ class MaskedObjective(object):
             normalize_mask = self.normalize_mask
 
         if normalize_mask:
-            mask = mask / T.sum(mask)
+            mask = mask / mask.sum()
 
-        return T.sum(self.loss_function(network_output, target, mask) * mask)
+        return (self.loss_function(network_output, target) * mask).sum()

--- a/lasagne/tests/test_objectives.py
+++ b/lasagne/tests/test_objectives.py
@@ -1,131 +1,160 @@
 import mock
 import numpy as np
+import theano
+import pytest
 
 
-def test_mse():
-    from lasagne.objectives import mse
+class TestObjectives:
+    @pytest.fixture
+    def input_layer(self, value):
+        from lasagne.layers import InputLayer
+        shape = np.array(value).shape
+        x = theano.shared(value)
+        return InputLayer(shape, input_var=x)
 
-    output = np.array([
-        [1.0, 0.0, 3.0, 0.0],
-        [-1.0, 0.0, -1.0, 0.0],
+
+    @pytest.fixture
+    def get_loss(self, loss_function, output, target):
+        from lasagne.objectives import Objective
+        input_layer = self.input_layer(output)
+        obj = Objective(input_layer, loss_function)
+        return obj.get_loss(target=target)
+
+
+    @pytest.fixture
+    def get_masked_loss(self, loss_function, output, target, mask):
+        from lasagne.objectives import MaskedObjective
+        input_layer = self.input_layer(output)
+        obj = MaskedObjective(input_layer, loss_function)
+        return obj.get_loss(target=target, mask=mask)
+
+
+    def test_mse(self):
+        from lasagne.objectives import mse
+
+        output = np.array([
+            [1.0, 0.0, 3.0, 0.0],
+            [-1.0, 0.0, -1.0, 0.0],
+            ])
+        target = np.zeros((2, 4))
+        mask = np.array([[1.0], [0.0]])
+
+        # Sqr-error sum = 1**2 + (-1)**2 + (-1)**2 + 3**2 = 12
+        # Mean is 1.5
+        result = self.get_loss(mse, output, target)
+        assert result.eval() == 1.5
+        # Masked error sum is 1**2 + 3**2
+        result_with_mask = self.get_masked_loss(mse, output, target, mask)
+        assert result_with_mask.eval() == 10
+
+
+    def test_crossentropy(self):
+        from lasagne.objectives import crossentropy
+
+        output = np.array([
+            [np.e ** -2]*4,
+            [np.e ** -1]*4,
+            ])
+        target = np.ones((2, 4))
+        mask = np.array([[0.0], [0.25]])
+
+        # Cross entropy sum is (2*4) + (1*4) = 12
+        # Mean is 1.5
+        result = self.get_loss(crossentropy, output, target)
+        assert result.eval() == 1.5
+        # Masked cross entropy sum is 1*4*0.25 = 1
+        result_with_mask = self.get_masked_loss(crossentropy, output, target, mask)
+        assert result_with_mask.eval() == 1
+
+
+    def test_multinomial_nll(self):
+        from lasagne.objectives import multinomial_nll
+
+        output = np.array([
+            [1.0, 1.0-np.e**-1, np.e**-1],
+            [1.0-np.e**-2, np.e**-2, 1.0],
+            [1.0-np.e**-3, 1.0, np.e**-3]
+            ])
+        target_1hot = np.array([2,1,2])
+        target_2d = np.array([
+            [0.0, 0.0, 1.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
         ])
-    target = np.zeros((2, 4))
-    mask = np.array([[1.0], [0.0]])
+        mask_1hot = np.array([0,1,1])
 
-    # Sqr-error sum = 1**2 + (-1)**2 + (-1)**2 + 3**2 = 12
-    # Mean is 1.5
-    result = mse(output, target)
-    assert result.eval() == 1.5
-    # Masked error sum is 1**2 + 3**2
-    result_with_mask = mse(output, target, mask)
-    assert result_with_mask.eval() == 10
-
-
-def test_crossentropy():
-    from lasagne.objectives import crossentropy
-
-    output = np.array([
-        [np.e ** -2]*4,
-        [np.e ** -1]*4,
-        ])
-    target = np.ones((2, 4))
-    mask = np.array([[0.0], [0.25]])
-
-    # Cross entropy sum is (2*4) + (1*4) = 12
-    # Mean is 1.5
-    result = crossentropy(output, target)
-    assert result.eval() == 1.5
-    # Masked cross entropy sum is 1*4*0.25 = 1
-    result_with_mask = crossentropy(output, target, mask)
-    assert result_with_mask.eval() == 1
+        # Multinomial NLL sum is 1 + 2 + 3 = 6
+        # Mean is 2
+        result = self.get_loss(multinomial_nll, output, target_1hot)
+        assert result.eval() == 2
+        # Multinomial NLL sum is (0*0 + 1*0 + 1*1) + (2*0 + 2*1 + 0*0)
+        # + (3*0 + 0*0 + 3*1) = 6
+        # Mean is 2
+        result = self.get_loss(multinomial_nll, output, target_2d)
+        assert result.eval() == 2
+        # Masked NLL sum is 2 + 3 = 5
+        result_with_mask = self.get_masked_loss(multinomial_nll, output, target_1hot, mask_1hot)
+        assert result_with_mask.eval() == 5
+        # Masked NLL sum is 2 + 3 = 5
+        result_with_mask = self.get_masked_loss(multinomial_nll, output, target_2d, mask_1hot)
+        assert result_with_mask.eval() == 5
 
 
-def test_multinomial_nll():
-    from lasagne.objectives import multinomial_nll
+    def test_objective(self):
+        from lasagne.objectives import Objective
 
-    output = np.array([
-        [1.0, 1.0-np.e**-1, np.e**-1],
-        [1.0-np.e**-2, np.e**-2, 1.0],
-        [1.0-np.e**-3, 1.0, np.e**-3]
-        ])
-    target_1hot = np.array([2,1,2])
-    target_2d = np.array([
-        [0.0, 0.0, 1.0],
-        [0.0, 1.0, 0.0],
-        [0.0, 0.0, 1.0],
-    ])
-    mask_1hot = np.array([0,1,1])
+        input_layer = mock.Mock()
+        loss_function = mock.Mock()
+        input, target, arg1, kwarg1 = (object(),) * 4
+        objective = Objective(input_layer, loss_function)
+        result = objective.get_loss(input, target, arg1, kwarg1=kwarg1)
 
-    # Multinomial NLL sum is 1 + 2 + 3 = 6
-    # Mean is 2
-    result = multinomial_nll(output, target_1hot)
-    assert result.eval() == 2
-    # Multinomial NLL sum is (0*0 + 1*0 + 1*1) + (2*0 + 2*1 + 0*0)
-    # + (3*0 + 0*0 + 3*1) = 6
-    # Mean is 2
-    result = multinomial_nll(output, target_2d)
-    assert result.eval() == 2
-    # Masked NLL sum is 2 + 3 = 5
-    result_with_mask = multinomial_nll(output, target_1hot, mask_1hot)
-    assert result_with_mask.eval() == 5
-    # Masked NLL sum is 2 + 3 = 5
-    result_with_mask = multinomial_nll(output, target_2d, mask_1hot)
-    assert result_with_mask.eval() == 5
+        # We expect that the input layer's `get_output` was called with
+        # the `input` argument we provided, plus the extra positional and
+        # keyword arguments.
+        input_layer.get_output.assert_called_with(input, arg1, kwarg1=kwarg1)
+        network_output = input_layer.get_output.return_value
+
+        # The `network_output` and `target` are fed into the loss
+        # function:
+        loss_function.assert_called_with(network_output, target)
+        assert result == loss_function.return_value.mean.return_value
 
 
-def test_objective():
-    from lasagne.objectives import Objective
+    def test_objective_no_target(self):
+        from lasagne.objectives import Objective
 
-    input_layer = mock.Mock()
-    loss_function = mock.Mock()
-    input, target, arg1, kwarg1 = (object(),) * 4
-    objective = Objective(input_layer, loss_function)
-    result = objective.get_loss(input, target, arg1, kwarg1=kwarg1)
+        input_layer = mock.Mock()
+        loss_function = mock.Mock()
+        input = object()
+        objective = Objective(input_layer, loss_function)
+        result = objective.get_loss(input)
 
-    # We expect that the input layer's `get_output` was called with
-    # the `input` argument we provided, plus the extra positional and
-    # keyword arguments.
-    input_layer.get_output.assert_called_with(input, arg1, kwarg1=kwarg1)
-    network_output = input_layer.get_output.return_value
+        input_layer.get_output.assert_called_with(input)
+        network_output = input_layer.get_output.return_value
 
-    # The `network_output` and `target` are fed into the loss
-    # function:
-    loss_function.assert_called_with(network_output, target)
-    assert result == loss_function.return_value
+        loss_function.assert_called_with(network_output, objective.target_var)
+        assert result == loss_function.return_value.mean.return_value
 
 
-def test_objective_no_target():
-    from lasagne.objectives import Objective
-
-    input_layer = mock.Mock()
-    loss_function = mock.Mock()
-    input = object()
-    objective = Objective(input_layer, loss_function)
-    result = objective.get_loss(input)
-
-    input_layer.get_output.assert_called_with(input)
-    network_output = input_layer.get_output.return_value
-
-    loss_function.assert_called_with(network_output, objective.target_var)
-    assert result == loss_function.return_value
-
-
-def test_masked_objective():
-    from lasagne.objectives import MaskedObjective
-
-    input_layer = mock.Mock()
-    loss_function = mock.Mock()
-    input, target, mask, arg1, kwarg1 = (object(),) * 5
-    objective = MaskedObjective(input_layer, loss_function)
-    result = objective.get_loss(input, target, mask, False, arg1, kwarg1=kwarg1)
-
-    # We expect that the input layer's `get_output` was called with
-    # the `input` argument we provided, plus the extra positional and
-    # keyword arguments.
-    input_layer.get_output.assert_called_with(input, arg1, kwarg1=kwarg1)
-    network_output = input_layer.get_output.return_value
-
-    # The `network_output` and `target` are fed into the loss
-    # function:
-    loss_function.assert_called_with(network_output, target, mask)
-    assert result == loss_function.return_value
+    # def test_masked_objective(self):
+    #     from lasagne.objectives import MaskedObjective
+    #
+    #     input_layer = mock.Mock()
+    #     loss_function = mock.Mock()
+    #     mask = mock.Mock()
+    #     input, target, arg1, kwarg1 = (object(),) * 4
+    #     objective = MaskedObjective(input_layer, loss_function)
+    #     result = objective.get_loss(input, target, mask, False, arg1, kwarg1=kwarg1)
+    #
+    #     # We expect that the input layer's `get_output` was called with
+    #     # the `input` argument we provided, plus the extra positional and
+    #     # keyword arguments.
+    #     input_layer.get_output.assert_called_with(input, arg1, kwarg1=kwarg1)
+    #     network_output = input_layer.get_output.return_value
+    #
+    #     # The `network_output` and `target` are fed into the loss
+    #     # function:
+    #     loss_function.assert_called_with(network_output, target, mask)
+    #     loss_function.return_value.__mul__.assert_called_with(mask)
+    #     assert result == loss_function.return_value.__mul__.return_value.sum.return_value

--- a/lasagne/tests/test_objectives.py
+++ b/lasagne/tests/test_objectives.py
@@ -178,7 +178,7 @@ class TestObjectives:
 
         input_layer = mock.Mock()
         loss_function = mock.Mock()
-        input, target, arg1, kwarg1 = (object(),) * 4
+        input, target, arg1, kwarg1 = object(), object(), object(), object()
         objective = Objective(input_layer, loss_function)
         result = objective.get_loss(input, target, 'mean', arg1,
                                     kwarg1=kwarg1)

--- a/lasagne/tests/test_objectives.py
+++ b/lasagne/tests/test_objectives.py
@@ -12,7 +12,6 @@ class TestObjectives:
         x = theano.shared(value)
         return InputLayer(shape, input_var=x)
 
-
     @pytest.fixture
     def get_loss(self, loss_function, output, target, aggregation=None):
         from lasagne.objectives import Objective
@@ -20,14 +19,14 @@ class TestObjectives:
         obj = Objective(input_layer, loss_function)
         return obj.get_loss(target=target, aggregation=aggregation)
 
-
     @pytest.fixture
-    def get_masked_loss(self, loss_function, output, target, mask, aggregation=None):
+    def get_masked_loss(self, loss_function, output, target, mask,
+                        aggregation=None):
         from lasagne.objectives import MaskedObjective
         input_layer = self.input_layer(output)
         obj = MaskedObjective(input_layer, loss_function)
-        return obj.get_loss(target=target, mask=mask, aggregation=aggregation)
-
+        return obj.get_loss(target=target, mask=mask,
+                            aggregation=aggregation)
 
     def test_mse(self):
         from lasagne.objectives import mse
@@ -67,13 +66,12 @@ class TestObjectives:
         result_with_mask = self.get_masked_loss(mse, output, target,
                                                 mask_2d, aggregation=None)
         assert result_with_mask.eval() == 10/8.0
-        result_with_mask = self.get_masked_loss(mse, output, target,
-                                                mask, aggregation='normalized_sum')
+        result_with_mask = self.get_masked_loss(mse, output, target, mask,
+                                                aggregation='normalized_sum')
         assert result_with_mask.eval() == 10
-        result_with_mask = self.get_masked_loss(mse, output, target,
-                                                mask_2d, aggregation='normalized_sum')
+        result_with_mask = self.get_masked_loss(mse, output, target, mask_2d,
+                                                aggregation='normalized_sum')
         assert result_with_mask.eval() == 10/4.0
-
 
     def test_binary_crossentropy(self):
         from lasagne.objectives import binary_crossentropy
@@ -89,31 +87,38 @@ class TestObjectives:
 
         # Cross entropy sum is (2*4) + (1*4) = 12
         # Mean is 1.5
-        result = self.get_loss(binary_crossentropy, output, target, aggregation='mean')
+        result = self.get_loss(binary_crossentropy, output, target,
+                               aggregation='mean')
         assert result.eval() == 1.5
-        result = self.get_loss(binary_crossentropy, output, target, aggregation='sum')
+        result = self.get_loss(binary_crossentropy, output, target,
+                               aggregation='sum')
         assert result.eval() == 12
 
         # Masked cross entropy sum is 1*4*1 = 4
-        result_with_mask = self.get_masked_loss(binary_crossentropy, output, target,
-                                                mask, aggregation='sum')
+        result_with_mask = self.get_masked_loss(binary_crossentropy,
+                                                output, target, mask,
+                                                aggregation='sum')
         assert result_with_mask.eval() == 4
-        result_with_mask = self.get_masked_loss(binary_crossentropy, output, target,
-                                                mask_2d, aggregation='sum')
+        result_with_mask = self.get_masked_loss(binary_crossentropy,
+                                                output, target, mask_2d,
+                                                aggregation='sum')
         assert result_with_mask.eval() == 4
-        result_with_mask = self.get_masked_loss(binary_crossentropy, output, target,
-                                                mask, aggregation='mean')
+        result_with_mask = self.get_masked_loss(binary_crossentropy,
+                                                output, target, mask,
+                                                aggregation='mean')
         assert result_with_mask.eval() == 1/2.0
-        result_with_mask = self.get_masked_loss(binary_crossentropy, output, target,
-                                                mask_2d, aggregation='mean')
+        result_with_mask = self.get_masked_loss(binary_crossentropy,
+                                                output, target, mask_2d,
+                                                aggregation='mean')
         assert result_with_mask.eval() == 1/2.0
-        result_with_mask = self.get_masked_loss(binary_crossentropy, output, target,
-                                                mask, aggregation='normalized_sum')
+        result_with_mask = self.get_masked_loss(binary_crossentropy,
+                                                output, target, mask,
+                                                aggregation='normalized_sum')
         assert result_with_mask.eval() == 4
-        result_with_mask = self.get_masked_loss(binary_crossentropy, output, target,
-                                                mask_2d, aggregation='normalized_sum')
+        result_with_mask = self.get_masked_loss(binary_crossentropy,
+                                                output, target, mask_2d,
+                                                aggregation='normalized_sum')
         assert result_with_mask.eval() == 1
-
 
     def test_categorical_crossentropy(self):
         from lasagne.objectives import categorical_crossentropy
@@ -123,13 +128,13 @@ class TestObjectives:
             [1.0-np.e**-2, np.e**-2, 1.0],
             [1.0-np.e**-3, 1.0, np.e**-3]
             ])
-        target_1hot = np.array([2,1,2])
+        target_1hot = np.array([2, 1, 2])
         target_2d = np.array([
             [0.0, 0.0, 1.0],
             [0.0, 1.0, 0.0],
             [0.0, 0.0, 1.0],
         ])
-        mask_1hot = np.array([0,1,1])
+        mask_1hot = np.array([0, 1, 1])
 
         # Multinomial NLL sum is 1 + 2 + 3 = 6
         # Mean is 2
@@ -152,21 +157,21 @@ class TestObjectives:
         # Masked NLL sum is 2 + 3 = 5
         result_with_mask = self.get_masked_loss(categorical_crossentropy,
                                                 output, target_1hot,
-                                                mask_1hot, aggregation='sum')
+                                                mask_1hot,
+                                                aggregation='sum')
         assert result_with_mask.eval() == 5
 
         # Masked NLL sum is 2 + 3 = 5
         result_with_mask = self.get_masked_loss(categorical_crossentropy,
-                                                output, target_2d,
-                                                mask_1hot, aggregation='mean')
+                                                output, target_2d, mask_1hot,
+                                                aggregation='mean')
         assert abs(result_with_mask.eval() - 5.0/3.0) < 1.0e-9
 
         # Masked NLL sum is 2 + 3 = 5
         result_with_mask = self.get_masked_loss(categorical_crossentropy,
-                                                output, target_2d,
-                                                mask_1hot, aggregation='normalized_sum')
+                                                output, target_2d, mask_1hot,
+                                                aggregation='normalized_sum')
         assert result_with_mask.eval() == 5.0/2.0
-
 
     def test_objective(self):
         from lasagne.objectives import Objective
@@ -175,7 +180,8 @@ class TestObjectives:
         loss_function = mock.Mock()
         input, target, arg1, kwarg1 = (object(),) * 4
         objective = Objective(input_layer, loss_function)
-        result = objective.get_loss(input, target, 'mean', arg1, kwarg1=kwarg1)
+        result = objective.get_loss(input, target, 'mean', arg1,
+                                    kwarg1=kwarg1)
 
         # We expect that the input layer's `get_output` was called with
         # the `input` argument we provided, plus the extra positional and
@@ -187,7 +193,6 @@ class TestObjectives:
         # function:
         loss_function.assert_called_with(network_output, target)
         assert result == loss_function.return_value.mean.return_value
-
 
     def test_objective_no_target(self):
         from lasagne.objectives import Objective
@@ -203,26 +208,3 @@ class TestObjectives:
 
         loss_function.assert_called_with(network_output, objective.target_var)
         assert result == loss_function.return_value.mean.return_value
-
-
-    # def test_masked_objective(self):
-    #     from lasagne.objectives import MaskedObjective
-    #
-    #     input_layer = mock.Mock()
-    #     loss_function = mock.Mock()
-    #     mask = mock.Mock()
-    #     input, target, arg1, kwarg1 = (object(),) * 4
-    #     objective = MaskedObjective(input_layer, loss_function)
-    #     result = objective.get_loss(input, target, mask, False, arg1, kwarg1=kwarg1)
-    #
-    #     # We expect that the input layer's `get_output` was called with
-    #     # the `input` argument we provided, plus the extra positional and
-    #     # keyword arguments.
-    #     input_layer.get_output.assert_called_with(input, arg1, kwarg1=kwarg1)
-    #     network_output = input_layer.get_output.return_value
-    #
-    #     # The `network_output` and `target` are fed into the loss
-    #     # function:
-    #     loss_function.assert_called_with(network_output, target, mask)
-    #     loss_function.return_value.__mul__.assert_called_with(mask)
-    #     assert result == loss_function.return_value.__mul__.return_value.sum.return_value

--- a/lasagne/tests/test_objectives.py
+++ b/lasagne/tests/test_objectives.py
@@ -22,11 +22,11 @@ class TestObjectives:
 
 
     @pytest.fixture
-    def get_masked_loss(self, loss_function, output, target, mask, mask_normalization=None):
+    def get_masked_loss(self, loss_function, output, target, mask, aggregation=None):
         from lasagne.objectives import MaskedObjective
         input_layer = self.input_layer(output)
         obj = MaskedObjective(input_layer, loss_function)
-        return obj.get_loss(target=target, mask=mask, mask_normalization=mask_normalization)
+        return obj.get_loss(target=target, mask=mask, aggregation=aggregation)
 
 
     def test_mse(self):
@@ -50,22 +50,28 @@ class TestObjectives:
 
         # Masked error sum is 1**2 + 3**2
         result_with_mask = self.get_masked_loss(mse, output, target,
-                                                mask, mask_normalization='none')
+                                                mask, aggregation='sum')
         assert result_with_mask.eval() == 10
         result_with_mask = self.get_masked_loss(mse, output, target,
-                                                mask_2d, mask_normalization='none')
+                                                mask_2d, aggregation='sum')
         assert result_with_mask.eval() == 10
         result_with_mask = self.get_masked_loss(mse, output, target,
-                                                mask, mask_normalization='mean')
+                                                mask, aggregation='mean')
         assert result_with_mask.eval() == 10/8.0
         result_with_mask = self.get_masked_loss(mse, output, target,
-                                                mask_2d, mask_normalization='mean')
+                                                mask_2d, aggregation='mean')
         assert result_with_mask.eval() == 10/8.0
         result_with_mask = self.get_masked_loss(mse, output, target,
-                                                mask, mask_normalization='sum')
+                                                mask, aggregation=None)
+        assert result_with_mask.eval() == 10/8.0
+        result_with_mask = self.get_masked_loss(mse, output, target,
+                                                mask_2d, aggregation=None)
+        assert result_with_mask.eval() == 10/8.0
+        result_with_mask = self.get_masked_loss(mse, output, target,
+                                                mask, aggregation='normalized_sum')
         assert result_with_mask.eval() == 10
         result_with_mask = self.get_masked_loss(mse, output, target,
-                                                mask_2d, mask_normalization='sum')
+                                                mask_2d, aggregation='normalized_sum')
         assert result_with_mask.eval() == 10/4.0
 
 
@@ -90,22 +96,22 @@ class TestObjectives:
 
         # Masked cross entropy sum is 1*4*1 = 4
         result_with_mask = self.get_masked_loss(binary_crossentropy, output, target,
-                                                mask, mask_normalization='none')
+                                                mask, aggregation='sum')
         assert result_with_mask.eval() == 4
         result_with_mask = self.get_masked_loss(binary_crossentropy, output, target,
-                                                mask_2d, mask_normalization='none')
+                                                mask_2d, aggregation='sum')
         assert result_with_mask.eval() == 4
         result_with_mask = self.get_masked_loss(binary_crossentropy, output, target,
-                                                mask, mask_normalization='mean')
+                                                mask, aggregation='mean')
         assert result_with_mask.eval() == 1/2.0
         result_with_mask = self.get_masked_loss(binary_crossentropy, output, target,
-                                                mask_2d, mask_normalization='mean')
+                                                mask_2d, aggregation='mean')
         assert result_with_mask.eval() == 1/2.0
         result_with_mask = self.get_masked_loss(binary_crossentropy, output, target,
-                                                mask, mask_normalization='sum')
+                                                mask, aggregation='normalized_sum')
         assert result_with_mask.eval() == 4
         result_with_mask = self.get_masked_loss(binary_crossentropy, output, target,
-                                                mask_2d, mask_normalization='sum')
+                                                mask_2d, aggregation='normalized_sum')
         assert result_with_mask.eval() == 1
 
 
@@ -146,19 +152,19 @@ class TestObjectives:
         # Masked NLL sum is 2 + 3 = 5
         result_with_mask = self.get_masked_loss(categorical_crossentropy,
                                                 output, target_1hot,
-                                                mask_1hot, mask_normalization='none')
+                                                mask_1hot, aggregation='sum')
         assert result_with_mask.eval() == 5
 
         # Masked NLL sum is 2 + 3 = 5
         result_with_mask = self.get_masked_loss(categorical_crossentropy,
                                                 output, target_2d,
-                                                mask_1hot, mask_normalization='mean')
+                                                mask_1hot, aggregation='mean')
         assert abs(result_with_mask.eval() - 5.0/3.0) < 1.0e-9
 
         # Masked NLL sum is 2 + 3 = 5
         result_with_mask = self.get_masked_loss(categorical_crossentropy,
                                                 output, target_2d,
-                                                mask_1hot, mask_normalization='sum')
+                                                mask_1hot, aggregation='normalized_sum')
         assert result_with_mask.eval() == 5.0/2.0
 
 

--- a/lasagne/tests/test_objectives.py
+++ b/lasagne/tests/test_objectives.py
@@ -48,8 +48,8 @@ class TestObjectives:
         assert result_with_mask.eval() == 10
 
 
-    def test_crossentropy(self):
-        from lasagne.objectives import crossentropy
+    def test_binary_crossentropy(self):
+        from lasagne.objectives import binary_crossentropy
 
         output = np.array([
             [np.e ** -2]*4,
@@ -60,15 +60,15 @@ class TestObjectives:
 
         # Cross entropy sum is (2*4) + (1*4) = 12
         # Mean is 1.5
-        result = self.get_loss(crossentropy, output, target)
+        result = self.get_loss(binary_crossentropy, output, target)
         assert result.eval() == 1.5
         # Masked cross entropy sum is 1*4*0.25 = 1
-        result_with_mask = self.get_masked_loss(crossentropy, output, target, mask)
+        result_with_mask = self.get_masked_loss(binary_crossentropy, output, target, mask)
         assert result_with_mask.eval() == 1
 
 
-    def test_multinomial_nll(self):
-        from lasagne.objectives import multinomial_nll
+    def test_categorical_crossentropy(self):
+        from lasagne.objectives import categorical_crossentropy
 
         output = np.array([
             [1.0, 1.0-np.e**-1, np.e**-1],
@@ -85,18 +85,22 @@ class TestObjectives:
 
         # Multinomial NLL sum is 1 + 2 + 3 = 6
         # Mean is 2
-        result = self.get_loss(multinomial_nll, output, target_1hot)
+        result = self.get_loss(categorical_crossentropy, output, target_1hot)
         assert result.eval() == 2
         # Multinomial NLL sum is (0*0 + 1*0 + 1*1) + (2*0 + 2*1 + 0*0)
         # + (3*0 + 0*0 + 3*1) = 6
         # Mean is 2
-        result = self.get_loss(multinomial_nll, output, target_2d)
+        result = self.get_loss(categorical_crossentropy, output, target_2d)
         assert result.eval() == 2
         # Masked NLL sum is 2 + 3 = 5
-        result_with_mask = self.get_masked_loss(multinomial_nll, output, target_1hot, mask_1hot)
+        result_with_mask = self.get_masked_loss(categorical_crossentropy,
+                                                output, target_1hot,
+                                                mask_1hot)
         assert result_with_mask.eval() == 5
         # Masked NLL sum is 2 + 3 = 5
-        result_with_mask = self.get_masked_loss(multinomial_nll, output, target_2d, mask_1hot)
+        result_with_mask = self.get_masked_loss(categorical_crossentropy,
+                                                output, target_2d,
+                                                mask_1hot)
         assert result_with_mask.eval() == 5
 
 

--- a/lasagne/tests/test_objectives.py
+++ b/lasagne/tests/test_objectives.py
@@ -6,26 +6,71 @@ def test_mse():
     from lasagne.objectives import mse
 
     output = np.array([
-        [1.0, 0.0, 1.0, 0.0],
+        [1.0, 0.0, 3.0, 0.0],
         [-1.0, 0.0, -1.0, 0.0],
         ])
     target = np.zeros((2, 4))
+    mask = np.array([[1.0], [0.0]])
 
+    # Sqr-error sum = 1**2 + (-1)**2 + (-1)**2 + 3**2 = 12
+    # Mean is 1.5
     result = mse(output, target)
-    assert result.eval() == 0.5
+    assert result.eval() == 1.5
+    # Masked error sum is 1**2 + 3**2
+    result_with_mask = mse(output, target, mask)
+    assert result_with_mask.eval() == 10
 
 
 def test_crossentropy():
     from lasagne.objectives import crossentropy
 
     output = np.array([
-        [np.e ** -2],
-        [np.e ** -1],
+        [np.e ** -2]*4,
+        [np.e ** -1]*4,
         ])
     target = np.ones((2, 4))
+    mask = np.array([[0.0], [0.25]])
 
+    # Cross entropy sum is (2*4) + (1*4) = 12
+    # Mean is 1.5
     result = crossentropy(output, target)
     assert result.eval() == 1.5
+    # Masked cross entropy sum is 1*4*0.25 = 1
+    result_with_mask = crossentropy(output, target, mask)
+    assert result_with_mask.eval() == 1
+
+
+def test_multinomial_nll():
+    from lasagne.objectives import multinomial_nll
+
+    output = np.array([
+        [1.0, 1.0-np.e**-1, np.e**-1],
+        [1.0-np.e**-2, np.e**-2, 1.0],
+        [1.0-np.e**-3, 1.0, np.e**-3]
+        ])
+    target_1hot = np.array([2,1,2])
+    target_2d = np.array([
+        [0.0, 0.0, 1.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+    ])
+    mask_1hot = np.array([0,1,1])
+
+    # Multinomial NLL sum is 1 + 2 + 3 = 6
+    # Mean is 2
+    result = multinomial_nll(output, target_1hot)
+    assert result.eval() == 2
+    # Multinomial NLL sum is (0*0 + 1*0 + 1*1) + (2*0 + 2*1 + 0*0)
+    # + (3*0 + 0*0 + 3*1) = 6
+    # Mean is 2
+    result = multinomial_nll(output, target_2d)
+    assert result.eval() == 2
+    # Masked NLL sum is 2 + 3 = 5
+    result_with_mask = multinomial_nll(output, target_1hot, mask_1hot)
+    assert result_with_mask.eval() == 5
+    # Masked NLL sum is 2 + 3 = 5
+    result_with_mask = multinomial_nll(output, target_2d, mask_1hot)
+    assert result_with_mask.eval() == 5
 
 
 def test_objective():
@@ -62,4 +107,25 @@ def test_objective_no_target():
     network_output = input_layer.get_output.return_value
 
     loss_function.assert_called_with(network_output, objective.target_var)
+    assert result == loss_function.return_value
+
+
+def test_masked_objective():
+    from lasagne.objectives import MaskedObjective
+
+    input_layer = mock.Mock()
+    loss_function = mock.Mock()
+    input, target, mask, arg1, kwarg1 = (object(),) * 5
+    objective = MaskedObjective(input_layer, loss_function)
+    result = objective.get_loss(input, target, mask, False, arg1, kwarg1=kwarg1)
+
+    # We expect that the input layer's `get_output` was called with
+    # the `input` argument we provided, plus the extra positional and
+    # keyword arguments.
+    input_layer.get_output.assert_called_with(input, arg1, kwarg1=kwarg1)
+    network_output = input_layer.get_output.return_value
+
+    # The `network_output` and `target` are fed into the loss
+    # function:
+    loss_function.assert_called_with(network_output, target, mask)
     assert result == loss_function.return_value


### PR DESCRIPTION
Masked objectives allow specified rows to be ignored when computing the loss value. For classification problems, this can be useful if training or test set is not an exact multiple of the mini-batch size; on the last mini-batch you provide a mask with zeros for the entries in the mini-batch for which you do not have data. For image segmentation problems the mask can be used to define a region of interest.