### PR TITLE
Flatten pixels layer

### DIFF
--- a/lasagne/layers/shape.py
+++ b/lasagne/layers/shape.py
@@ -9,6 +9,7 @@ from .base import Layer
 
 __all__ = [
     "FlattenLayer",
+    "FlattenPixelsLayer",
     "flatten",
     "PadLayer",
     "pad",
@@ -24,6 +25,14 @@ class FlattenLayer(Layer):
         return input.flatten(2)
 
 flatten = FlattenLayer # shortcut
+
+
+class FlattenPixelsLayer(Layer):
+    def get_output_shape_for(self, input_shape):
+        return (input_shape[0] * int(np.prod(input_shape[2:])), input_shape[1])
+
+    def get_output_for(self, input, *args, **kwargs):
+        return input.dimshuffle(1,0,2,3).flatten(2).dimshuffle(1,0)
 
 
 class PadLayer(Layer):


### PR DESCRIPTION
`FlattenPixelsLayer` reshapes a (batch,channel,height,width) array into (batch_height_width,channel) array for per pixel softmax. Its main use is for segmentation in a block-by-block basis. 

Segmentation can be performed without the use of `FlattenPixelsLayer` in a sliding window fashion by extracting a window surrounding each output pixel. This however is very slow, since the entire net must be evaluated once for each output pixel, with some parallelism achieved through the use of mini-batches. Significant performance improvements can be realised by segmenting complete images or blocks of images. `FlattenPixelsLayer` has one downside, in that the batch, height and width dimensions are collapsed into one, meaning that you have to reshape the target values at training time and reshape the network output when in use. Other than that, its still quite usable. :)