### PR TITLE
Py3k

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
+# Virtualenv
 bin/
 include/
 src/
+
+# Dataset used in examples
 mnist.pkl.gz
 
 # Byte-compiled / optimized / DLL files

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+bin/
+include/
+src/
+mnist.pkl.gz
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.4"
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libatlas-dev libatlas-base-dev liblapack-dev gfortran

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
 language: python
 python:
   - "2.7"
-virtualenv:
-  system_site_packages: true
 before_install:
-  - sudo apt-get install -qq python-numpy python-scipy libatlas3gf-base libatlas-dev liblapack-dev gfortran
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libatlas-dev libatlas-base-dev liblapack-dev gfortran
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b
+  - export PATH=/home/travis/miniconda/bin:$PATH
+  - conda update --yes conda
 install:
-  - pip install -r requirements.txt
-  - python setup.py dev
+  - travis_retry conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy
+  - travis_retry pip install -r requirements.txt
+  - travis_retry python setup.py dev
 script: travis_wait py.test --runslow
 cache: apt

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -1,10 +1,20 @@
 from __future__ import print_function
 
-import cPickle as pickle
 import gzip
 import itertools
-import urllib
+import pickle
 import os
+import sys
+
+PY2 = sys.version_info[0] == 2
+
+if PY2:
+    from urllib import urlretrieve
+    pickle_load = lambda f, encoding: pickle.load(f)
+else:
+    from urllib.request import urlretrieve
+    pickle_load = lambda f, encoding: pickle.load(f, encoding=encoding)
+
 
 import numpy as np
 import lasagne
@@ -23,15 +33,12 @@ MOMENTUM = 0.9
 
 
 def _load_data(url=DATA_URL, filename=DATA_FILENAME):
-    try:
-        with gzip.open(filename, 'rb') as f:
-            data = pickle.load(f)
-    except (IOError, EOFError):
+    if not os.path.exists(filename):
         print("Downloading MNIST")
-        urllib.urlretrieve(url, filename)
-        with gzip.open(filename, 'rb') as f:
-            data = pickle.load(f)
-    return data
+        urlretrieve(url, filename)
+
+    with gzip.open(filename, 'rb') as f:
+        return pickle_load(f, encoding='latin-1')
 
 
 def load_data():

--- a/lasagne/__init__.py
+++ b/lasagne/__init__.py
@@ -2,10 +2,10 @@
 Tools to train neural nets in Theano
 """
 
-import nonlinearities
-import init
-import layers
-import objectives
-import regularization
-import updates
-import utils
+from . import nonlinearities
+from . import init
+from . import layers
+from . import objectives
+from . import regularization
+from . import updates
+from . import utils

--- a/lasagne/regularization.py
+++ b/lasagne/regularization.py
@@ -1,7 +1,7 @@
 import theano
 import theano.tensor as T
 
-import layers
+from . import layers
 
 
 def l2(layer, include_biases=False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/Theano/Theano.git@b84464261ffa1d451097ac5e5243dcd8f7e0ff62#egg=Theano
+git+https://github.com/Theano/Theano.git@b84464261ffa1d451097ac5e5243dcd8f7e0ff62#egg=Theano

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,8 @@ setup(
     long_description="\n\n".join([README, CHANGES]),
     classifiers=[
         "Development Status :: 3 - Alpha",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.4",
         ],
     keywords="",
     author="Sander Dieleman",


### PR DESCRIPTION
Intended to supersede #119, this pull request attempts to add Python 3 compatibility with fewer changes to the code.

I think it's fair to say with this, that we have experimental Python 3 support.  It's maybe not bug-free, given that we don't have 100% coverage, but once Python 3 users start using this (hopefully I will soon), we might be able to declare this stable.

I haven't included a `_compat.py` module for now. The `mnist.py` example uses its own little `if PY2` block to do the right imports.  Why?  Because I think it might be common that people look at the examples and copy code as a starting point for their own experiments.  For those users, we wouldn't want them to have imports from a private Lasagne compatibility module (which I think `_compat.py` should be; we don't want to support a compat API).  That's of course once we start having a compatibility module; we don't have with this pull request.