### PR TITLE
Cross-channel Local response normalization

### DIFF
--- a/lasagne/__init__.py
+++ b/lasagne/__init__.py
@@ -9,4 +9,3 @@ from . import objectives
 from . import regularization
 from . import updates
 from . import utils
-from . import normalization

--- a/lasagne/__init__.py
+++ b/lasagne/__init__.py
@@ -9,3 +9,4 @@ from . import objectives
 from . import regularization
 from . import updates
 from . import utils
+from . import normalization

--- a/lasagne/layers/__init__.py
+++ b/lasagne/layers/__init__.py
@@ -7,3 +7,4 @@ from .conv import *
 from .pool import *
 from .shape import *
 from .merge import *
+from .normalization import *

--- a/lasagne/layers/normalization.py
+++ b/lasagne/layers/normalization.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 
 """
+This file contains code from pylearn2, which is convered by the following
+license:
+
+
 Copyright (c) 2011--2014, Université de Montréal
 All rights reserved.
 

--- a/lasagne/layers/normalization.py
+++ b/lasagne/layers/normalization.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
+
 This file contains code from pylearn2, which is convered by the following
 license:
 
@@ -19,8 +20,8 @@ modification, are permitted provided that the following conditions are met:
    and/or other materials provided with the distribution.
 
 3. Neither the name of the copyright holder nor the names of its contributors
-   may be used to endorse or promote products derived from this software without
-   specific prior written permission.
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -48,6 +49,7 @@ from .base import Layer
 __all__ = [
     "LocalResponseNormalization2DLayer",
 ]
+
 
 class LocalResponseNormalization2DLayer(Layer):
     """
@@ -79,7 +81,8 @@ class LocalResponseNormalization2DLayer(Layer):
             - beta: see equation above
             - n: number of adjacent channels to normalize over.
         """
-        super(LocalResponseNormalization2DLayer, self).__init__(incoming, **kwargs)
+        super(LocalResponseNormalization2DLayer, self).__init__(incoming,
+                                                                **kwargs)
         self.alpha = alpha
         self.k = k
         self.beta = beta
@@ -98,9 +101,10 @@ class LocalResponseNormalization2DLayer(Layer):
         input_sqr = T.sqr(input)
         b, ch, r, c = input_shape
         extra_channels = T.alloc(0., b, ch + 2*half_n, r, c)
-        input_sqr = T.set_subtensor(extra_channels[:,half_n:half_n+ch,:,:], input_sqr)
+        input_sqr = T.set_subtensor(extra_channels[:, half_n:half_n+ch, :, :],
+                                    input_sqr)
         scale = self.k
         for i in range(self.n):
-            scale += self.alpha * input_sqr[:,i:i+ch,:,:]
+            scale += self.alpha * input_sqr[:, i:i+ch, :, :]
         scale = scale ** self.beta
         return input / scale

--- a/lasagne/layers/normalization.py
+++ b/lasagne/layers/normalization.py
@@ -1,0 +1,61 @@
+
+import numpy as np
+import theano
+import theano.tensor as T
+
+from .. import init
+from .. import nonlinearities
+from ..theano_extensions import conv
+
+from .base import Layer
+
+
+__all__ = [
+    "LocalResponseNormalization2DLayer",
+]
+
+class LocalResponseNormalization2DLayer(Layer):
+    """
+
+    Cross-Channel Local Response Normalization for 2D feature maps, in the
+    style of AlexNet.
+
+    Aggregation is purely across channels, not within channels,
+    and performed "pixelwise".
+
+    Input order is assumed to be BC01.
+
+    If the value of the ith channel is x_i, the output is
+
+    x_i = x_i / (k + ( alpha \sum_j x_j^2 ))^beta
+
+    where the summation is performed over this position on n neighboring channels.
+
+    This code is adapted from pylearn2.
+    """
+
+    def __init__(self, incoming, alpha=1e-4, k=2, beta=0.75, n=5, **kwargs):
+        super(LocalResponseNormalization2DLayer, self).__init__(incoming, **kwargs)
+        self.alpha = alpha
+        self.k = k
+        self.beta = beta
+        self.n = n
+        if n % 2 == 0:
+            raise NotImplementedError("Only works with odd n")
+
+    def get_output_shape_for(self, input_shape):
+        return input_shape
+
+    def get_output_for(self, input, input_shape=None, *args, **kwargs):
+        if input_shape is None:
+            input_shape = self.input_shape
+        half_n = self.n // 2
+        input_sqr = T.sqr(input)
+        b, ch, r, c = input_shape
+        extra_channels = T.alloc(0., b, ch + 2*half_n, r, c)
+        input_sqr = T.set_subtensor(extra_channels[:,half_n:half_n+ch,:,:], input_sqr)
+        scale = self.k
+        for i in xrange(self.n):
+            scale += self.alpha * input_sqr[:,i:i+ch,:,:]
+        scale = scale ** self.beta
+        return input / scale

--- a/lasagne/layers/normalization.py
+++ b/lasagne/layers/normalization.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
 Copyright (c) 2011--2014, Université de Montréal
 All rights reserved.

--- a/lasagne/layers/normalization.py
+++ b/lasagne/layers/normalization.py
@@ -55,9 +55,10 @@ class LocalResponseNormalization2DLayer(Layer):
     def get_output_shape_for(self, input_shape):
         return input_shape
 
-    def get_output_for(self, input, input_shape=None, *args, **kwargs):
-        if input_shape is None:
-            input_shape = self.input_shape
+    def get_output_for(self, input, *args, **kwargs):
+        input_shape = self.input_shape
+        if any(s is None for s in input_shape):
+            input_shape = input.shape
         half_n = self.n // 2
         input_sqr = T.sqr(input)
         b, ch, r, c = input_shape

--- a/lasagne/layers/normalization.py
+++ b/lasagne/layers/normalization.py
@@ -55,7 +55,7 @@ class LocalResponseNormalization2DLayer(Layer):
         extra_channels = T.alloc(0., b, ch + 2*half_n, r, c)
         input_sqr = T.set_subtensor(extra_channels[:,half_n:half_n+ch,:,:], input_sqr)
         scale = self.k
-        for i in xrange(self.n):
+        for i in range(self.n):
             scale += self.alpha * input_sqr[:,i:i+ch,:,:]
         scale = scale ** self.beta
         return input / scale

--- a/lasagne/layers/normalization.py
+++ b/lasagne/layers/normalization.py
@@ -1,3 +1,32 @@
+"""
+Copyright (c) 2011--2014, Université de Montréal
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
 
 import numpy as np
 import theano

--- a/lasagne/layers/normalization.py
+++ b/lasagne/layers/normalization.py
@@ -35,16 +35,9 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
-import numpy as np
-import theano
 import theano.tensor as T
 
-from .. import init
-from .. import nonlinearities
-from ..theano_extensions import conv
-
 from .base import Layer
-
 
 __all__ = [
     "LocalResponseNormalization2DLayer",

--- a/lasagne/layers/normalization.py
+++ b/lasagne/layers/normalization.py
@@ -16,25 +16,34 @@ __all__ = [
 
 class LocalResponseNormalization2DLayer(Layer):
     """
-
-    Cross-Channel Local Response Normalization for 2D feature maps, in the
-    style of AlexNet.
+    Cross-channel Local Response Normalization for 2D feature maps.
 
     Aggregation is purely across channels, not within channels,
     and performed "pixelwise".
 
-    Input order is assumed to be BC01.
+    Input order is assumed to be `BC01`.
 
-    If the value of the ith channel is x_i, the output is
+    If the value of the ith channel is :math:`x_i`, the output is
 
-    x_i = x_i / (k + ( alpha \sum_j x_j^2 ))^beta
+    .. math::
 
-    where the summation is performed over this position on n neighboring channels.
+        x_i = \frac{x_i}{ (k + ( \alpha \sum_j x_j^2 ))^\beta }
+
+    where the summation is performed over this position on :math:`n`
+    neighboring channels.
 
     This code is adapted from pylearn2.
     """
 
     def __init__(self, incoming, alpha=1e-4, k=2, beta=0.75, n=5, **kwargs):
+        """
+        :parameters:
+            - incoming: input layer or shape
+            - alpha: see equation above
+            - k: see equation above
+            - beta: see equation above
+            - n: number of adjacent channels to normalize over.
+        """
         super(LocalResponseNormalization2DLayer, self).__init__(incoming, **kwargs)
         self.alpha = alpha
         self.k = k

--- a/lasagne/layers/normalization.py
+++ b/lasagne/layers/normalization.py
@@ -2,7 +2,7 @@
 
 """
 
-This file contains code from pylearn2, which is convered by the following
+This file contains code from pylearn2, which is covered by the following
 license:
 
 

--- a/lasagne/tests/layers/test_normalization.py
+++ b/lasagne/tests/layers/test_normalization.py
@@ -84,7 +84,6 @@ class TestLocalResponseNormalization2DLayer:
 
     @pytest.fixture
     def input_data(self, input_layer, rng):
-        print input_layer.shape
         return rng.randn(*input_layer.shape).astype(theano.config.floatX)
 
     @pytest.fixture

--- a/lasagne/tests/layers/test_normalization.py
+++ b/lasagne/tests/layers/test_normalization.py
@@ -1,0 +1,29 @@
+from mock import Mock
+import numpy as np
+import pytest
+import importlib
+import theano
+
+import lasagne
+
+
+class TestLocalResponseNormalization2DLayer:
+
+    @pytest.fixture
+    def layer(self, dummy_input_layer):
+        from lasagne.layers.normalization import\
+                LocalResponseNormalization2DLayer
+
+        layer = LocalResponseNormalization2DLayer(dummy_input_layer,
+                                                  alpha=1.5,
+                                                  k=2,
+                                                  beta=0.75,
+                                                  n=0.75)
+
+        return layer
+
+    def test_get_params(self, layer):
+        assert len(layer.get_params()) == 0
+
+    def test_get_bias_params(self, layer):
+        assert len(layer.get_bias_params()) == 0

--- a/lasagne/tests/layers/test_normalization.py
+++ b/lasagne/tests/layers/test_normalization.py
@@ -36,15 +36,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 
-from mock import Mock
 import numpy as np
 import pytest
-import importlib
 import theano
 
 import lasagne
-from lasagne.utils import floatX
-
 
 def ground_truth_normalizer(c01b, k, n, alpha, beta):
     out = np.zeros(c01b.shape)

--- a/lasagne/tests/layers/test_normalization.py
+++ b/lasagne/tests/layers/test_normalization.py
@@ -1,3 +1,41 @@
+# -*- coding: utf-8 -*-
+
+"""
+
+This file contains code from pylearn2, which is covered by the following
+license:
+
+
+Copyright (c) 2011--2014, Université de Montréal
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
+
 from mock import Mock
 import numpy as np
 import pytest
@@ -5,21 +43,74 @@ import importlib
 import theano
 
 import lasagne
+from lasagne.utils import floatX
+
+
+def ground_truth_normalizer(c01b, k, n, alpha, beta):
+    out = np.zeros(c01b.shape)
+
+    for r in xrange(out.shape[1]):
+        for c in xrange(out.shape[2]):
+            for x in xrange(out.shape[3]):
+                out[:, r, c, x] = ground_truth_normalize_row(
+                        row=c01b[:, r, c, x],
+                        k=k, n=n, alpha=alpha, beta=beta)
+    return out
+
+
+def ground_truth_normalize_row(row, k, n, alpha, beta):
+    assert row.ndim == 1
+    out = np.zeros(row.shape)
+    for i in xrange(row.shape[0]):
+        s = k
+        tot = 0
+        for j in xrange(max(0, i-n//2), min(row.shape[0], i+n//2+1)):
+            tot += 1
+            sq = row[j] ** 2.
+            assert sq > 0.
+            assert s >= k
+            assert alpha > 0.
+            s += alpha * sq
+            assert s >= k
+        assert tot <= n
+        assert s >= k
+        s = s ** beta
+        out[i] = row[i] / s
+    return out
 
 
 class TestLocalResponseNormalization2DLayer:
 
     @pytest.fixture
-    def layer(self, dummy_input_layer):
+    def rng(self):
+        return np.random.RandomState([2013, 2])
+
+    @pytest.fixture
+    def input_data(self, input_layer, rng):
+        print input_layer.shape
+        return rng.randn(*input_layer.shape).astype(theano.config.floatX)
+
+    @pytest.fixture
+    def input_layer(self):
+        from lasagne.layers.input import InputLayer
+        channels = 15
+        rows = 3
+        cols = 4
+        batch_size = 2
+        shape = (batch_size, channels, rows, cols)
+        return InputLayer(shape)
+
+    @pytest.fixture
+    def layer(self, input_layer):
+
         from lasagne.layers.normalization import\
                 LocalResponseNormalization2DLayer
 
-        layer = LocalResponseNormalization2DLayer(dummy_input_layer,
+        layer = LocalResponseNormalization2DLayer(input_layer,
                                                   alpha=1.5,
                                                   k=2,
                                                   beta=0.75,
-                                                  n=0.75)
-
+                                                  n=5)
         return layer
 
     def test_get_params(self, layer):
@@ -27,3 +118,20 @@ class TestLocalResponseNormalization2DLayer:
 
     def test_get_bias_params(self, layer):
         assert len(layer.get_bias_params()) == 0
+
+    def test_normalization(self, input_data, input_layer, layer):
+        X = input_layer.input_var
+        lrn = theano.function([X], layer.get_output(X))
+        out = lrn(input_data)
+
+        # ground_truth_normalizer assumes c01b
+        input_data_c01b = input_data.transpose([1, 2, 3, 0])
+        ground_out = ground_truth_normalizer(input_data_c01b,
+                                             n=layer.n, k=layer.k,
+                                             alpha=layer.alpha,
+                                             beta=layer.beta)
+        ground_out = np.transpose(ground_out, [3, 0, 1, 2])
+
+        assert out.shape == ground_out.shape
+
+        assert np.allclose(out, ground_out)

--- a/lasagne/tests/layers/test_normalization.py
+++ b/lasagne/tests/layers/test_normalization.py
@@ -42,6 +42,7 @@ import theano
 
 import lasagne
 
+
 def ground_truth_normalizer(c01b, k, n, alpha, beta):
     out = np.zeros(c01b.shape)
 

--- a/lasagne/tests/layers/test_normalization.py
+++ b/lasagne/tests/layers/test_normalization.py
@@ -46,9 +46,9 @@ import lasagne
 def ground_truth_normalizer(c01b, k, n, alpha, beta):
     out = np.zeros(c01b.shape)
 
-    for r in xrange(out.shape[1]):
-        for c in xrange(out.shape[2]):
-            for x in xrange(out.shape[3]):
+    for r in range(out.shape[1]):
+        for c in range(out.shape[2]):
+            for x in range(out.shape[3]):
                 out[:, r, c, x] = ground_truth_normalize_row(
                         row=c01b[:, r, c, x],
                         k=k, n=n, alpha=alpha, beta=beta)
@@ -58,10 +58,10 @@ def ground_truth_normalizer(c01b, k, n, alpha, beta):
 def ground_truth_normalize_row(row, k, n, alpha, beta):
     assert row.ndim == 1
     out = np.zeros(row.shape)
-    for i in xrange(row.shape[0]):
+    for i in range(row.shape[0]):
         s = k
         tot = 0
-        for j in xrange(max(0, i-n//2), min(row.shape[0], i+n//2+1)):
+        for j in range(max(0, i-n//2), min(row.shape[0], i+n//2+1)):
             tot += 1
             sq = row[j] ** 2.
             assert sq > 0.


### PR DESCRIPTION
This is a first stab at a 2D cross-channel LRN layer. Lines 52 through 61 are pretty much verbatim from `pylearn2`, except for some variable renaming. I added some comments and the `lasagne` wrapping. It gets the job done but perhaps it could be generalized to handle `cb01` as well as `bc01`, though in the former case `cuda-convnet` could be preferable. Maybe a 1D version would also be desirable, though I don't know if anyone does this for 1D data.