### PR TITLE
Weight Norm Constraints

### DIFF
--- a/lasagne/tests/test_updates.py
+++ b/lasagne/tests/test_updates.py
@@ -1,0 +1,54 @@
+import pytest
+
+PCT_TOLERANCE = 1E-6
+
+def test_norm_constraint_abs():
+    import numpy as np
+    import theano
+    from lasagne.updates import norm_constraint, compute_norms
+
+    abs_max = 0.01
+
+    param = theano.shared(
+        np.random.randn(100, 200).astype(theano.config.floatX)
+    )
+
+    update = norm_constraint(param, abs_max=abs_max)
+
+    apply_update = theano.function([], [], updates=[(param, update)])
+    apply_update()
+
+    assert param.dtype == update.dtype
+    assert (np.max(compute_norms(param.get_value()))
+            <= abs_max*(1 + PCT_TOLERANCE))
+
+
+
+def test_norm_constraint_rel():
+    import numpy as np
+    import theano
+    from lasagne.updates import norm_constraint, compute_norms
+
+    rel_max = 1.0
+
+    param = theano.shared(
+        np.random.randn(100, 200).astype(theano.config.floatX)
+    )
+
+    orig_avg_norm = np.mean(compute_norms(param.get_value()))
+
+    # update: multiply by 5
+    update = np.array(5.0, dtype=theano.config.floatX)*param
+
+    update = norm_constraint(update, param, rel_max=rel_max)
+
+    apply_update = theano.function([], [], updates=[(param, update)])
+    apply_update()
+
+    assert param.dtype == update.dtype
+    assert (np.max(compute_norms(param.get_value()))
+            <= rel_max * (1 + PCT_TOLERANCE) * orig_avg_norm)
+
+
+
+

--- a/lasagne/tests/test_updates.py
+++ b/lasagne/tests/test_updates.py
@@ -3,124 +3,63 @@ import pytest
 PCT_TOLERANCE = 1E-5
 
 
-def test_compute_norms():
-    import numpy as np
-    import theano
-    from lasagne.updates import compute_norms
-
-    array = np.random.randn(10, 20, 30, 40).astype(theano.config.floatX)
-
-    norms = compute_norms(array)
-
-    assert array.dtype == norms.dtype
-    assert norms.shape[0] == array.shape[0]
-
-
-def test_compute_norms_axes():
-    import numpy as np
-    import theano
-    from lasagne.updates import compute_norms
-
-    array = np.random.randn(10, 20, 30, 40).astype(theano.config.floatX)
-
-    norms = compute_norms(array, norm_axes=(0, 2))
-
-    assert array.dtype == norms.dtype
-    assert norms.shape == (array.shape[1], array.shape[3])
-
-
-def test_compute_norms_ndim6_raises():
-    import numpy as np
-    import theano
-    from lasagne.updates import compute_norms
-
-    array = np.random.randn(1, 2, 3, 4, 5, 6).astype(theano.config.floatX)
-
-    with pytest.raises(ValueError) as excinfo:
-        norms = compute_norms(array)
-
-    assert "Unsupported tensor dimensionality" in str(excinfo.value)
-
-
 def test_norm_constraint_abs():
     import numpy as np
     import theano
-    from lasagne.updates import norm_constraint, compute_norms
+    from lasagne.updates import norm_constraint
+    from lasagne.utils import compute_norms
 
-    abs_max = 0.01
+    max_norm = 0.01
 
     param = theano.shared(
         np.random.randn(100, 200).astype(theano.config.floatX)
     )
 
-    update = norm_constraint(param, abs_max=abs_max)
+    update = norm_constraint(param, max_norm)
 
     apply_update = theano.function([], [], updates=[(param, update)])
     apply_update()
 
     assert param.dtype == update.dtype
     assert (np.max(compute_norms(param.get_value()))
-            <= abs_max*(1 + PCT_TOLERANCE))
-
-
-def test_norm_constraint_rel():
-    import numpy as np
-    import theano
-    from lasagne.updates import norm_constraint, compute_norms
-
-    rel_max = 1.0
-
-    param = theano.shared(
-        np.random.randn(100, 200).astype(theano.config.floatX)
-    )
-
-    orig_avg_norm = np.mean(compute_norms(param.get_value()))
-
-    # update: multiply by 5
-    update = np.array(5.0, dtype=theano.config.floatX)*param
-
-    update = norm_constraint(update, param, rel_max=rel_max)
-
-    apply_update = theano.function([], [], updates=[(param, update)])
-    apply_update()
-
-    assert param.dtype == update.dtype
-    assert (np.max(compute_norms(param.get_value()))
-            <= rel_max * (1 + PCT_TOLERANCE) * orig_avg_norm)
+            <= max_norm*(1 + PCT_TOLERANCE))
 
 
 def test_norm_constraint_norm_axes():
     import numpy as np
     import theano
-    from lasagne.updates import norm_constraint, compute_norms
+    from lasagne.updates import norm_constraint
+    from lasagne.utils import compute_norms
 
-    abs_max = 0.01
+    max_norm = 0.01
     norm_axes = (0, 2)
 
     param = theano.shared(
         np.random.randn(10, 20, 30, 40).astype(theano.config.floatX)
     )
 
-    update = norm_constraint(param, abs_max=abs_max, norm_axes=norm_axes)
+    update = norm_constraint(param, max_norm, norm_axes=norm_axes)
 
     apply_update = theano.function([], [], updates=[(param, update)])
     apply_update()
 
     assert param.dtype == update.dtype
     assert (np.max(compute_norms(param.get_value(), norm_axes=norm_axes))
-            <= abs_max*(1 + PCT_TOLERANCE))
+            <= max_norm*(1 + PCT_TOLERANCE))
+
 
 def test_norm_constraint_abs_dim6_raises():
     import numpy as np
     import theano
-    from lasagne.updates import norm_constraint, compute_norms
+    from lasagne.updates import norm_constraint
+    from lasagne.utils import compute_norms
 
-    abs_max = 0.01
+    max_norm = 0.01
 
     param = theano.shared(
         np.random.randn(1, 2, 3, 4, 5, 6).astype(theano.config.floatX)
     )
 
     with pytest.raises(ValueError) as excinfo:
-        update = norm_constraint(param, abs_max=abs_max)
+        update = norm_constraint(param, max_norm)
     assert "Unsupported tensor dimensionality" in str(excinfo.value)

--- a/lasagne/tests/test_updates.py
+++ b/lasagne/tests/test_updates.py
@@ -1,6 +1,6 @@
-import pytest
 
 PCT_TOLERANCE = 1E-5
+
 
 def test_compute_norms():
     import numpy as np
@@ -13,6 +13,7 @@ def test_compute_norms():
 
     assert array.dtype == norms.dtype
     assert norms.shape[0] == array.shape[0]
+
 
 def test_compute_norms_axes():
     import numpy as np
@@ -46,7 +47,6 @@ def test_norm_constraint_abs():
     assert param.dtype == update.dtype
     assert (np.max(compute_norms(param.get_value()))
             <= abs_max*(1 + PCT_TOLERANCE))
-
 
 
 def test_norm_constraint_rel():
@@ -95,7 +95,3 @@ def test_norm_constraint_norm_axes():
     assert param.dtype == update.dtype
     assert (np.max(compute_norms(param.get_value(), norm_axes=norm_axes))
             <= abs_max*(1 + PCT_TOLERANCE))
-
-
-
-

--- a/lasagne/tests/test_updates.py
+++ b/lasagne/tests/test_updates.py
@@ -1,3 +1,4 @@
+import pytest
 
 PCT_TOLERANCE = 1E-5
 
@@ -26,6 +27,19 @@ def test_compute_norms_axes():
 
     assert array.dtype == norms.dtype
     assert norms.shape == (array.shape[1], array.shape[3])
+
+
+def test_compute_norms_ndim6_raises():
+    import numpy as np
+    import theano
+    from lasagne.updates import compute_norms
+
+    array = np.random.randn(1, 2, 3, 4, 5, 6).astype(theano.config.floatX)
+
+    with pytest.raises(ValueError) as excinfo:
+        norms = compute_norms(array)
+
+    assert "Unsupported tensor dimensionality" in str(excinfo.value)
 
 
 def test_norm_constraint_abs():
@@ -95,3 +109,18 @@ def test_norm_constraint_norm_axes():
     assert param.dtype == update.dtype
     assert (np.max(compute_norms(param.get_value(), norm_axes=norm_axes))
             <= abs_max*(1 + PCT_TOLERANCE))
+
+def test_norm_constraint_abs_dim6_raises():
+    import numpy as np
+    import theano
+    from lasagne.updates import norm_constraint, compute_norms
+
+    abs_max = 0.01
+
+    param = theano.shared(
+        np.random.randn(1, 2, 3, 4, 5, 6).astype(theano.config.floatX)
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        update = norm_constraint(param, abs_max=abs_max)
+    assert "Unsupported tensor dimensionality" in str(excinfo.value)

--- a/lasagne/tests/test_updates.py
+++ b/lasagne/tests/test_updates.py
@@ -3,7 +3,7 @@ import pytest
 PCT_TOLERANCE = 1E-5
 
 
-def test_norm_constraint_abs():
+def test_norm_constraint():
     import numpy as np
     import theano
     from lasagne.updates import norm_constraint
@@ -48,7 +48,7 @@ def test_norm_constraint_norm_axes():
             <= max_norm*(1 + PCT_TOLERANCE))
 
 
-def test_norm_constraint_abs_dim6_raises():
+def test_norm_constraint_dim6_raises():
     import numpy as np
     import theano
     from lasagne.updates import norm_constraint

--- a/lasagne/tests/test_updates.py
+++ b/lasagne/tests/test_updates.py
@@ -1,6 +1,31 @@
 import pytest
 
-PCT_TOLERANCE = 1E-6
+PCT_TOLERANCE = 1E-5
+
+def test_compute_norms():
+    import numpy as np
+    import theano
+    from lasagne.updates import compute_norms
+
+    array = np.random.randn(10, 20, 30, 40).astype(theano.config.floatX)
+
+    norms = compute_norms(array)
+
+    assert array.dtype == norms.dtype
+    assert norms.shape[0] == array.shape[0]
+
+def test_compute_norms_axes():
+    import numpy as np
+    import theano
+    from lasagne.updates import compute_norms
+
+    array = np.random.randn(10, 20, 30, 40).astype(theano.config.floatX)
+
+    norms = compute_norms(array, norm_axes=(0, 2))
+
+    assert array.dtype == norms.dtype
+    assert norms.shape == (array.shape[1], array.shape[3])
+
 
 def test_norm_constraint_abs():
     import numpy as np
@@ -48,6 +73,28 @@ def test_norm_constraint_rel():
     assert param.dtype == update.dtype
     assert (np.max(compute_norms(param.get_value()))
             <= rel_max * (1 + PCT_TOLERANCE) * orig_avg_norm)
+
+
+def test_norm_constraint_norm_axes():
+    import numpy as np
+    import theano
+    from lasagne.updates import norm_constraint, compute_norms
+
+    abs_max = 0.01
+    norm_axes = (0, 2)
+
+    param = theano.shared(
+        np.random.randn(10, 20, 30, 40).astype(theano.config.floatX)
+    )
+
+    update = norm_constraint(param, abs_max=abs_max, norm_axes=norm_axes)
+
+    apply_update = theano.function([], [], updates=[(param, update)])
+    apply_update()
+
+    assert param.dtype == update.dtype
+    assert (np.max(compute_norms(param.get_value(), norm_axes=norm_axes))
+            <= abs_max*(1 + PCT_TOLERANCE))
 
 
 

--- a/lasagne/tests/test_utils.py
+++ b/lasagne/tests/test_utils.py
@@ -1,0 +1,39 @@
+import pytest
+
+def test_compute_norms():
+    import numpy as np
+    import theano
+    from lasagne.utils import compute_norms
+
+    array = np.random.randn(10, 20, 30, 40).astype(theano.config.floatX)
+
+    norms = compute_norms(array)
+
+    assert array.dtype == norms.dtype
+    assert norms.shape[0] == array.shape[0]
+
+
+def test_compute_norms_axes():
+    import numpy as np
+    import theano
+    from lasagne.utils import compute_norms
+
+    array = np.random.randn(10, 20, 30, 40).astype(theano.config.floatX)
+
+    norms = compute_norms(array, norm_axes=(0, 2))
+
+    assert array.dtype == norms.dtype
+    assert norms.shape == (array.shape[1], array.shape[3])
+
+
+def test_compute_norms_ndim6_raises():
+    import numpy as np
+    import theano
+    from lasagne.utils import compute_norms
+
+    array = np.random.randn(1, 2, 3, 4, 5, 6).astype(theano.config.floatX)
+
+    with pytest.raises(ValueError) as excinfo:
+        norms = compute_norms(array)
+
+    assert "Unsupported tensor dimensionality" in str(excinfo.value)

--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -150,6 +150,33 @@ def norm_constraint(orig_update, param=None, abs_max=None, rel_max=None,
     the lesser of `abs_max` (if provided) and `rel_max` (if provided) times
     the average norm of the values originally stored in `param`.
 
+    Weight vectors violating the constraint are rescaled so that they are
+    within the allowed range.
+
+
+    :parameters:
+        - orig_update : TensorVariable
+            Theano expression for original update
+        - param : TheanoSharedVariable
+            Shared variable containing initial parameter values.
+            (Required if `rel_max` is used)
+        - abs_max : scalar
+            This value sets the absolute maximum value allowed for the
+            incoming weight vectors after the update.
+            (Optional)
+        - rel_max : scalar
+            This value sets the relative maximum value allowed for the
+            incoming weight vectors after the update.  The relative maximum
+            is computed by multiplying this value by the average incoming
+            weight vector norm for the values originally stored in the
+            `param` shared variable.
+
+    :returns:
+        - update : TensorVariable
+            Original update with rescaling applied to weight vectors
+            that violate the specified constraints.
+
+
     Right now this supports:
         * 2D param matrices with shape (input_dim, output_dim)
         * {3,4,5}D param tensors with shape

--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -183,8 +183,8 @@ def norm_constraint(tensor_var, param=None, abs_max=None, rel_max=None,
 
 
     :returns:
-        - update : TensorVariable
-            Original update with rescaling applied to weight vectors
+        - constrained_output : TensorVariable
+            Input `tensor_var` with rescaling applied to weight vectors
             that violate the specified constraints.
 
 
@@ -235,10 +235,11 @@ def norm_constraint(tensor_var, param=None, abs_max=None, rel_max=None,
     dtype = np.dtype(theano.config.floatX).type
     norms = T.sqrt(T.sum(T.sqr(tensor_var), axis=sum_over))
     target_norms = T.clip(norms, 0, dtype(constraint))
-    update = (tensor_var *
-              (target_norms / (dtype(epsilon) + norms)).dimshuffle(*broadcast))
+    constrained_output = \
+        (tensor_var *
+         (target_norms / (dtype(epsilon) + norms)).dimshuffle(*broadcast))
 
-    return update
+    return constrained_output
 
 
 def compute_norms(array, norm_axes=None):

--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -227,17 +227,11 @@ def norm_constraint(tensor_var, param=None, abs_max=None, rel_max=None,
             "Please use `norm_axes`".format(ndim)
         )
 
-    # broadcast over dimensions in `sum_over`
-    count = iter(range(ndim))
-    broadcast = tuple('x' if d in sum_over else next(count)
-                      for d in range(ndim))
-
     dtype = np.dtype(theano.config.floatX).type
-    norms = T.sqrt(T.sum(T.sqr(tensor_var), axis=sum_over))
+    norms = T.sqrt(T.sum(T.sqr(tensor_var), axis=sum_over, keepdims=True))
     target_norms = T.clip(norms, 0, dtype(constraint))
     constrained_output = \
-        (tensor_var *
-         (target_norms / (dtype(epsilon) + norms)).dimshuffle(*broadcast))
+        (tensor_var * (target_norms / (dtype(epsilon) + norms)))
 
     return constrained_output
 

--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -170,6 +170,7 @@ def norm_constraint(orig_update, param=None, abs_max=None, rel_max=None,
             is computed by multiplying this value by the average incoming
             weight vector norm for the values originally stored in the
             `param` shared variable.
+            (Optional)
 
     :returns:
         - update : TensorVariable

--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -217,13 +217,14 @@ def norm_constraint(tensor_var, param=None, abs_max=None, rel_max=None,
 
     if norm_axes is not None:
         sum_over = tuple(norm_axes)
-    elif ndim == 2: # DenseLayer
+    elif ndim == 2:  # DenseLayer
         sum_over = (0,)
-    elif ndim in [3, 4, 5]: # Conv{1,2,3}DLayer
+    elif ndim in [3, 4, 5]:  # Conv{1,2,3}DLayer
         sum_over = tuple(range(1, ndim))
     else:
         raise ValueError(
-            "Unsupported update dimensionality {}".format(tensor_var.ndim)
+            "Unsupported tensor dimensionality {}."
+            "Please use `norm_axes`".format(ndim)
         )
 
     # broadcast over dimensions in `sum_over`
@@ -258,18 +259,18 @@ def compute_norms(array, norm_axes=None):
             1D array of incoming weight vector norms.
     '''
 
-
     ndim = array.ndim
 
     if norm_axes is not None:
         sum_over = tuple(norm_axes)
-    elif ndim == 2: # DenseLayer
+    elif ndim == 2:  # DenseLayer
         sum_over = (0,)
-    elif ndim in [3, 4, 5]: # Conv{1,2,3}DLayer
+    elif ndim in [3, 4, 5]:  # Conv{1,2,3}DLayer
         sum_over = tuple(d for d in range(1, ndim))
     else:
         raise ValueError(
-            "Unsupported update dimensionality {}".format(array.ndim)
+            "Unsupported tensor dimensionality {}."
+            "Please use `norm_axes`".format(array.ndim)
         )
 
     norms = np.sqrt(np.sum(array**2, axis=sum_over))

--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -6,6 +6,7 @@ import numpy as np
 
 import theano
 import theano.tensor as T
+from theano.config import floatX
 
 
 def sgd(loss, all_params, learning_rate):
@@ -167,21 +168,8 @@ def norm_constraint(orig_update, param=None, abs_max=None, rel_max=None):
         )
 
     norms = T.sqrt(T.sum(T.sqr(orig_update), axis=sum_over))
-    target_norms = T.clip(norms, 0, constraint)
-    update = orig_update * (target_norms / (1e-7 + norms)).dimshuffle(*broadcast)
+    target_norms = T.clip(norms, 0, floatX(constraint))
+    update = (orig_update *
+              (target_norms / (1e-7 + norms)).dimshuffle(*broadcast))
 
     return update
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -181,18 +181,35 @@ def norm_constraint(tensor_var, param=None, abs_max=None, rel_max=None,
             very small or zero norms.
             (Optional)
 
-
     :returns:
         - constrained_output : TensorVariable
             Input `tensor_var` with rescaling applied to weight vectors
             that violate the specified constraints.
 
+    :usage:
+        >>> # Weight norm constraints
+        >>> from collections import OrderedDict
+        >>> updates = nesterov_momentum(loss, all_params, learning_rate)
+        >>> updates = OrderedDict(updates)
+        >>> # Absolute constraint of 5.0 for `param1`
+        >>> updates[param1] = norm_constraint(updates[param1], abs_max=5.0)
+        >>> # Relative constraint of 1.0 for `param2`
+        >>> updates[param2] = norm_constraint(updates[param2], rel_max=1.0)
 
-    Right now this has predefined norm ops for:
-        * 2D dense weight matrices with shape (input_dim, output_dim)
-        * {3,4,5}D convolutional filter tensors with shape
-                    (output_chans, input_chans, dim0, dim1, ...)
-    For other uses, you can use the `norm_axes` argument.
+        >>> # Gradient clipping
+        >>> all_grads = theano.grad(loss, all_params)
+        >>> # Clip all gradients to 5.0
+        >>> updates = []
+        >>> for param, grad in zip(all_params, all_grads):
+        >>>     clipped_grad = norm_constraint(grad, abs_max=5.0)
+        >>>     updates.append((param, param - learning_rate * clipped_grad))
+
+    :note:
+        Right now this has predefined norm ops for:
+            * 2D dense weight matrices with shape (input_dim, output_dim)
+            * {3,4,5}D convolutional filter tensors with shape
+                        (output_chans, input_chans, dim0, dim1, ...)
+        For other uses, you can use the `norm_axes` argument.
     '''
 
     constraint = None

--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -218,10 +218,8 @@ def norm_constraint(tensor_var, param=None, abs_max=None, rel_max=None,
         sum_over = tuple(norm_axes)
     elif ndim == 2: # DenseLayer
         sum_over = (0,)
-        broadcast = ('x', 0)
     elif ndim in [3, 4, 5]: # Conv{1,2,3}DLayer
         sum_over = tuple(range(1, ndim))
-        broadcast = (0,) + tuple('x' for d in range(1, ndim))
     else:
         raise ValueError(
             "Unsupported update dimensionality {}".format(tensor_var.ndim)

--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -175,8 +175,10 @@ def norm_constraint(orig_update, param=None, abs_max=None, rel_max=None):
         constraint = rel_max * avg_norm
 
     if abs_max is not None:
-
         constraint = abs_max if constraint is None else min(abs_max, constraint)
+
+    if constraint is None:
+        return orig_update
 
     if orig_update.ndim == 4:
         sum_over = (1, 2, 3)

--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -242,7 +242,7 @@ def compute_norms(array, norm_axes=None):
 
     :parameters:
         - array : ndarray
-            Weight array from a DenseLayer or Conv{3,4,5}DLayer.
+            Weight array
         - norm_axes : sequence (list or tuple)
             The axes over which to compute the norm.  This overrides the
             default norm axes defined for the number of dimensions

--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -188,10 +188,11 @@ def norm_constraint(tensor_var, param=None, abs_max=None, rel_max=None,
             that violate the specified constraints.
 
 
-    Right now this supports:
-        * 2D param matrices with shape (input_dim, output_dim)
-        * {3,4,5}D param tensors with shape
+    Right now this has predefined norm ops for:
+        * 2D dense weight matrices with shape (input_dim, output_dim)
+        * {3,4,5}D convolutional filter tensors with shape
                     (output_chans, input_chans, dim0, dim1, ...)
+    For other uses, you can use the `norm_axes` argument.
     '''
 
     constraint = None

--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -223,7 +223,20 @@ def norm_constraint(orig_update, param=None, abs_max=None, rel_max=None,
 
     return update
 
+
 def compute_norms(array):
+    '''
+    Compute incoming weight vector norms.
+
+    :parameters:
+        - array : ndarray
+            Weight array from a DenseLayer or Conv{3,4,5}DLayer.
+
+    :returns:
+        - norms : 1D array
+            1D array of incoming weight vector norms.
+    '''
+
 
     ndim = array.ndim
 

--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -11,7 +11,7 @@ import theano.tensor as T
 def sgd(loss, all_params, learning_rate):
     all_grads = theano.grad(loss, all_params)
     updates = []
-    
+
     for param_i, grad_i in zip(all_params, all_grads):
         updates.append((param_i, param_i - learning_rate * grad_i))
 
@@ -21,7 +21,7 @@ def sgd(loss, all_params, learning_rate):
 def momentum(loss, all_params, learning_rate, momentum=0.9):
     all_grads = theano.grad(loss, all_params)
     updates = []
-    
+
     for param_i, grad_i in zip(all_params, all_grads):
         mparam_i = theano.shared(np.zeros(param_i.get_value().shape, dtype=theano.config.floatX))
         v = momentum * mparam_i - learning_rate * grad_i
@@ -36,7 +36,7 @@ def momentum(loss, all_params, learning_rate, momentum=0.9):
 def nesterov_momentum(loss, all_params, learning_rate, momentum=0.9):
     all_grads = theano.grad(loss, all_params)
     updates = []
-    
+
     for param_i, grad_i in zip(all_params, all_grads):
         mparam_i = theano.shared(np.zeros(param_i.get_value().shape, dtype=theano.config.floatX))
         v = momentum * mparam_i - learning_rate * grad_i # new momemtum
@@ -49,7 +49,7 @@ def nesterov_momentum(loss, all_params, learning_rate, momentum=0.9):
 
 def adagrad(loss, all_params, learning_rate=1.0, epsilon=1e-6):
     """
-    epsilon is not included in the typical formula, 
+    epsilon is not included in the typical formula,
     See "Notes on AdaGrad" by Chris Dyer for more info.
     """
     all_grads = theano.grad(loss, all_params)
@@ -112,4 +112,76 @@ def adadelta(loss, all_params, learning_rate=1.0, rho=0.95, epsilon=1e-6):
         updates.append((acc_delta_i, acc_delta_i_new))
 
     return updates
+
+
+def norm_constraint(orig_update, param=None, abs_max=None, rel_max=None):
+    '''
+    Max weight norm constraints
+
+    This takes a parameter update and rescales it so that incoming weight
+    norms are below a specified constraint value.  The constraint value is
+    the lesser of `abs_max` (if provided) and `rel_max` (if provided) times
+    the average norm of the values originally stored in `param`.
+
+    Right now this supports:
+        * 2D param matrices with shape (input_dim, output_dim)
+        * 4D param tensors with shape (output_chans, input_chans, dim0, dim1)
+    '''
+
+    constraint = None
+
+    if rel_max is not None:
+
+        if param is None:
+            raise ValueError("`rel_max` requires that `param` is provided")
+
+        # Compute average norm of `param`
+        vals = param.get_value()
+        if vals.ndim == 4: # Conv2DLayer weights [chan_out, chan_in, dim0, dim1]
+            sum_over = (1, 2, 3)
+        elif vals.ndim == 2: # DenseLayer weights [in_dim, out_dim]
+            sum_over = (0,)
+        else:
+            raise ValueError(
+                "Unsupported param dimensionality {}".format(vals.ndim)
+            )
+
+        avg_norm = np.mean(np.sqrt(np.sum(vals**2, axis=sum_over)))
+
+        constraint = rel_max * avg_norm
+
+    if abs_max is not None:
+
+        constraint = abs_max if constraint is None else min(abs_max, constraint)
+
+
+    if orig_update.ndim == 4:
+        sum_over = (1, 2, 3)
+        broadcast = (0, 'x', 'x', 'x')
+    elif orig_update.ndim == 2:
+        sum_over = (0,)
+        broadcast = ('x', 0)
+    else:
+        raise ValueError(
+            "Unsupported update dimensionality {}".format(orig_update.ndim)
+        )
+
+    norms = T.sqrt(T.sum(T.sqr(orig_update), axis=sum_over))
+    target_norms = T.clip(norms, 0, constraint)
+    update = orig_update * (target_norms / (1e-7 + norms)).dimshuffle(*broadcast)
+
+    return update
+
+
+
+
+
+
+
+
+
+
+
+
+
 

--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -229,7 +229,7 @@ def norm_constraint(tensor_var, param=None, abs_max=None, rel_max=None,
 
     # broadcast over dimensions in `sum_over`
     count = iter(range(ndim))
-    broadcast = tuple('x' if d in sum_over else count.next()
+    broadcast = tuple('x' if d in sum_over else next(count)
                       for d in range(ndim))
 
     dtype = np.dtype(theano.config.floatX).type

--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -224,7 +224,7 @@ def norm_constraint(tensor_var, param=None, abs_max=None, rel_max=None,
     else:
         raise ValueError(
             "Unsupported tensor dimensionality {}."
-            "Please use `norm_axes`".format(ndim)
+            "Must specify `norm_axes`".format(ndim)
         )
 
     dtype = np.dtype(theano.config.floatX).type
@@ -261,11 +261,11 @@ def compute_norms(array, norm_axes=None):
     elif ndim == 2:  # DenseLayer
         sum_over = (0,)
     elif ndim in [3, 4, 5]:  # Conv{1,2,3}DLayer
-        sum_over = tuple(d for d in range(1, ndim))
+        sum_over = tuple(range(1, ndim))
     else:
         raise ValueError(
             "Unsupported tensor dimensionality {}."
-            "Please use `norm_axes`".format(array.ndim)
+            "Must specify `norm_axes`".format(array.ndim)
         )
 
     norms = np.sqrt(np.sum(array**2, axis=sum_over))

--- a/lasagne/utils.py
+++ b/lasagne/utils.py
@@ -117,3 +117,51 @@ def concatenate(tensor_list, axis=0):
         offset += tensor.shape[axis]
 
     return out
+
+
+def compute_norms(array, norm_axes=None):
+    '''
+    Compute incoming weight vector norms.
+
+    :parameters:
+        - array : ndarray
+            Weight array
+        - norm_axes : sequence (list or tuple)
+            The axes over which to compute the norm.  This overrides the
+            default norm axes defined for the number of dimensions
+            in array
+            (Optional)
+
+    :returns:
+        - norms : 1D array
+            1D array of incoming weight vector norms.
+    :usage:
+        >>> array = np.random.randn(100, 200)
+        >>> norms = compute_norms(array)
+        >>> norms.shape
+        (200,)
+
+        >>> norms = compute_norms(array, norm_axes=(1,))
+        >>> norms.shape
+        (100,)
+
+    '''
+
+
+    ndim = array.ndim
+
+    if norm_axes is not None:
+        sum_over = tuple(norm_axes)
+    elif ndim == 2:  # DenseLayer
+        sum_over = (0,)
+    elif ndim in [3, 4, 5]:  # Conv{1,2,3}DLayer
+        sum_over = tuple(range(1, ndim))
+    else:
+        raise ValueError(
+            "Unsupported tensor dimensionality {}."
+            "Must specify `norm_axes`".format(array.ndim)
+        )
+
+    norms = np.sqrt(np.sum(array**2, axis=sum_over))
+
+    return norms


### PR DESCRIPTION
Here's an attempt at weight norm constraints as we discussed in #84.  I also did a little PEP8 cleanup in update.py (mostly line lengths stuff).

Unless I totally overlooked an easy assumption, it seems like we have to handle all the different types of parameter dimensionalities differently (not quite as clean as in the default Uniform initializer).  So, it makes assumptions about the mean of the dimensions in a 2D and 4D parameter array.  

Let me know what you guys think.  I'll add better docs later.

