### PR TITLE
Deprecate lasagne.utils.concatenate and do not use it within library

### DIFF
--- a/docs/modules/utils.rst
+++ b/docs/modules/utils.rst
@@ -8,6 +8,5 @@
 .. autofunction:: as_theano_expression
 .. autofunction:: one_hot
 .. autofunction:: unique
-.. autofunction:: concatenate
 .. autofunction:: compute_norms
 

--- a/lasagne/layers/merge.py
+++ b/lasagne/layers/merge.py
@@ -26,9 +26,7 @@ class ConcatLayer(MultipleInputsLayer):
         return tuple(output_shape)
 
     def get_output_for(self, inputs, *args, **kwargs):
-        # unfortunately the gradient of T.concatenate has no GPU
-        # implementation, so we have to do this differently.
-        return utils.concatenate(inputs, axis=self.axis)
+        return T.concatenate(inputs, axis=self.axis)
 
 concat = ConcatLayer # shortcut
 

--- a/lasagne/utils.py
+++ b/lasagne/utils.py
@@ -69,54 +69,16 @@ def unique(l):
 
 def concatenate(tensor_list, axis=0):
     """
-    Alternative implementation of `theano.tensor.concatenate`.
-    This function does exactly the same thing, but contrary to Theano's own
-    implementation, the gradient is implemented on the GPU.
-
-    Backpropagating through `theano.tensor.concatenate` yields slowdowns
-    because the inverse operation (splitting) needs to be done on the CPU.
-    This implementation does not have that problem.
-
-    :usage:
-        >>> x, y = theano.tensor.matrices('x', 'y')
-        >>> c = concatenate([x, y], axis=1)
-
-    :parameters:
-        - tensor_list : list
-            list of Theano tensor expressions that should be concatenated.
-        - axis : int
-            the tensors will be joined along this axis.
-
-    :returns:
-        - out : tensor
-            the concatenated tensor expression.
+    This function was used to work around a deficiency in Theano's
+    `theano.tensor.concatenate` (the inverse operation, splitting, was not
+    available on GPU). As of 2015-02-25, this deficiency has been removed,
+    so this workaround is not needed any longer and will be removed for
+    Lasagne's first release. Use `theano.tensor.concatenate` instead.
     """
-    if axis < 0:
-        axis += tensor_list[0].ndim
-
-    concat_size = sum(tensor.shape[axis] for tensor in tensor_list)
-
-    output_shape = ()
-    for k in range(axis):
-        output_shape += (tensor_list[0].shape[k],)
-    output_shape += (concat_size,)
-    for k in range(axis + 1, tensor_list[0].ndim):
-        output_shape += (tensor_list[0].shape[k],)
-
-    out = T.zeros(output_shape)
-    offset = 0
-    for tensor in tensor_list:
-        indices = ()
-        for k in range(axis):
-            indices += (slice(None),)
-        indices += (slice(offset, offset + tensor.shape[axis]),)
-        for k in range(axis + 1, tensor_list[0].ndim):
-            indices += (slice(None),)
-
-        out = T.set_subtensor(out[indices], tensor)
-        offset += tensor.shape[axis]
-
-    return out
+    import warnings
+    warnings.warn("lasagne.utils.concatenate will be removed.\n"
+                  "Use theano.tensor.concatenate instead.")
+    return T.concatenate(tensor_list, axis)
 
 
 def compute_norms(array, norm_axes=None):


### PR DESCRIPTION
Addresses #151 (but does not close it; we still need to remove the function for the first release).