### PR TITLE
Misc diagnostics/cleanup to examples

### DIFF
--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -190,15 +190,19 @@ def main(num_epochs=NUM_EPOCHS):
     iter_funcs = create_iter_functions(dataset, output_layer)
 
     print("Starting training...")
-    for epoch in train(iter_funcs, dataset):
-        print("Epoch {} of {}".format(epoch['number'], num_epochs))
-        print("  training loss:\t\t{:.6f}".format(epoch['train_loss']))
-        print("  validation loss:\t\t{:.6f}".format(epoch['valid_loss']))
-        print("  validation accuracy:\t\t{:.2f} %%".format(
-              epoch['valid_accuracy'] * 100))
+    try:
+        for epoch in train(iter_funcs, dataset):
+            print("Epoch {} of {}".format(epoch['number'], num_epochs))
+            print("  training loss:\t\t{:.6f}".format(epoch['train_loss']))
+            print("  validation loss:\t\t{:.6f}".format(epoch['valid_loss']))
+            print("  validation accuracy:\t\t{:.2f} %%".format(
+                epoch['valid_accuracy'] * 100))
 
-        if epoch['number'] >= num_epochs:
-            break
+            if epoch['number'] >= num_epochs:
+                break
+
+    except KeyboardInterrupt:
+        pass
 
     return output_layer
 

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -9,6 +9,7 @@ import numpy as np
 import lasagne
 import theano
 import theano.tensor as T
+import time
 
 PY2 = sys.version_info[0] == 2
 
@@ -193,9 +194,12 @@ def main(num_epochs=NUM_EPOCHS):
     iter_funcs = create_iter_functions(dataset, output_layer)
 
     print("Starting training...")
+    now = time.time()
     try:
         for epoch in train(iter_funcs, dataset):
-            print("Epoch {} of {}".format(epoch['number'], num_epochs))
+            print("Epoch {} of {} took {:.3f}s".format(
+                epoch['number'], num_epochs, time.time() - now))
+            now = time.time()
             print("  training loss:\t\t{:.6f}".format(epoch['train_loss']))
             print("  validation loss:\t\t{:.6f}".format(epoch['valid_loss']))
             print("  validation accuracy:\t\t{:.2f} %%".format(

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -182,7 +182,10 @@ def train(iter_funcs, dataset, batch_size=BATCH_SIZE):
 
 
 def main(num_epochs=NUM_EPOCHS):
+    print("Loading data...")
     dataset = load_data()
+
+    print("Building model and compiling functions...")
     output_layer = build_model(
         input_dim=dataset['input_dim'],
         output_dim=dataset['output_dim'],

--- a/examples/mnist.py
+++ b/examples/mnist.py
@@ -191,11 +191,11 @@ def main(num_epochs=NUM_EPOCHS):
 
     print("Starting training...")
     for epoch in train(iter_funcs, dataset):
-        print("Epoch %d of %d" % (epoch['number'], num_epochs))
-        print("  training loss:\t\t%.6f" % epoch['train_loss'])
-        print("  validation loss:\t\t%.6f" % epoch['valid_loss'])
-        print("  validation accuracy:\t\t%.2f %%" %
-              (epoch['valid_accuracy'] * 100))
+        print("Epoch {} of {}".format(epoch['number'], num_epochs))
+        print("  training loss:\t\t{:.6f}".format(epoch['train_loss']))
+        print("  validation loss:\t\t{:.6f}".format(epoch['valid_loss']))
+        print("  validation accuracy:\t\t{:.2f} %%".format(
+              epoch['valid_accuracy'] * 100))
 
         if epoch['number'] >= num_epochs:
             break

--- a/examples/mnist_conv.py
+++ b/examples/mnist_conv.py
@@ -93,8 +93,10 @@ def build_model(input_width, input_height, output_dim,
 
 
 def main(num_epochs=NUM_EPOCHS):
+    print("Loading data...")
     dataset = load_data()
 
+    print("Building model and compiling functions...")
     output_layer = build_model(
         input_height=dataset['input_height'],
         input_width=dataset['input_width'],

--- a/examples/mnist_conv.py
+++ b/examples/mnist_conv.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import lasagne
 import theano
 import theano.tensor as T
+import time
 
 from mnist import _load_data
 from mnist import create_iter_functions
@@ -110,9 +111,12 @@ def main(num_epochs=NUM_EPOCHS):
         )
 
     print("Starting training...")
+    now = time.time()
     try:
         for epoch in train(iter_funcs, dataset):
-            print("Epoch {} of {}".format(epoch['number'], num_epochs))
+            print("Epoch {} of {} took {:.3f}s".format(
+                epoch['number'], num_epochs, time.time() - now))
+            now = time.time()
             print("  training loss:\t\t{:.6f}".format(epoch['train_loss']))
             print("  validation loss:\t\t{:.6f}".format(epoch['valid_loss']))
             print("  validation accuracy:\t\t{:.2f} %%".format(

--- a/examples/mnist_conv.py
+++ b/examples/mnist_conv.py
@@ -108,15 +108,19 @@ def main(num_epochs=NUM_EPOCHS):
         )
 
     print("Starting training...")
-    for epoch in train(iter_funcs, dataset):
-        print("Epoch {} of {}".format(epoch['number'], num_epochs))
-        print("  training loss:\t\t{:.6f}".format(epoch['train_loss']))
-        print("  validation loss:\t\t{:.6f}".format(epoch['valid_loss']))
-        print("  validation accuracy:\t\t{:.2f} %%".format(
-              epoch['valid_accuracy'] * 100))
+    try:
+        for epoch in train(iter_funcs, dataset):
+            print("Epoch {} of {}".format(epoch['number'], num_epochs))
+            print("  training loss:\t\t{:.6f}".format(epoch['train_loss']))
+            print("  validation loss:\t\t{:.6f}".format(epoch['valid_loss']))
+            print("  validation accuracy:\t\t{:.2f} %%".format(
+                epoch['valid_accuracy'] * 100))
 
-        if epoch['number'] >= num_epochs:
-            break
+            if epoch['number'] >= num_epochs:
+                break
+
+    except KeyboardInterrupt:
+        pass
 
     return output_layer
 

--- a/examples/mnist_conv.py
+++ b/examples/mnist_conv.py
@@ -109,11 +109,11 @@ def main(num_epochs=NUM_EPOCHS):
 
     print("Starting training...")
     for epoch in train(iter_funcs, dataset):
-        print("Epoch %d of %d" % (epoch['number'], num_epochs))
-        print("  training loss:\t\t%.6f" % epoch['train_loss'])
-        print("  validation loss:\t\t%.6f" % epoch['valid_loss'])
-        print("  validation accuracy:\t\t%.2f %%" %
-              (epoch['valid_accuracy'] * 100))
+        print("Epoch {} of {}".format(epoch['number'], num_epochs))
+        print("  training loss:\t\t{:.6f}".format(epoch['train_loss']))
+        print("  validation loss:\t\t{:.6f}".format(epoch['valid_loss']))
+        print("  validation accuracy:\t\t{:.2f} %%".format(
+              epoch['valid_accuracy'] * 100))
 
         if epoch['number'] >= num_epochs:
             break

--- a/examples/mnist_conv_cc.py
+++ b/examples/mnist_conv_cc.py
@@ -126,16 +126,19 @@ def main(num_epochs=NUM_EPOCHS):
     )
 
     print("Starting training...")
+    try:
+        for epoch in train(iter_funcs, dataset):
+            print("Epoch {} of {}".format(epoch['number'], num_epochs))
+            print("  training loss:\t\t{:.6f}".format(epoch['train_loss']))
+            print("  validation loss:\t\t{:.6f}".format(epoch['valid_loss']))
+            print("  validation accuracy:\t\t{:.2f} %%".format(
+                epoch['valid_accuracy'] * 100))
 
-    for epoch in train(iter_funcs, dataset):
-        print("Epoch {} of {}".format(epoch['number'], num_epochs))
-        print("  training loss:\t\t{:.6f}".format(epoch['train_loss']))
-        print("  validation loss:\t\t{:.6f}".format(epoch['valid_loss']))
-        print("  validation accuracy:\t\t{:.2f} %%".format(
-              epoch['valid_accuracy'] * 100))
+            if epoch['number'] >= num_epochs:
+                break
 
-        if epoch['number'] >= num_epochs:
-            break
+    except KeyboardInterrupt:
+        pass
 
     return output_layer
 

--- a/examples/mnist_conv_cc.py
+++ b/examples/mnist_conv_cc.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import lasagne
 import theano
 import theano.tensor as T
+import time
 
 from lasagne.layers import cuda_convnet
 
@@ -128,9 +129,12 @@ def main(num_epochs=NUM_EPOCHS):
     )
 
     print("Starting training...")
+    now = time.time()
     try:
         for epoch in train(iter_funcs, dataset):
-            print("Epoch {} of {}".format(epoch['number'], num_epochs))
+            print("Epoch {} of {} took {:.3f}s".format(
+                epoch['number'], num_epochs, time.time() - now))
+            now = time.time()
             print("  training loss:\t\t{:.6f}".format(epoch['train_loss']))
             print("  validation loss:\t\t{:.6f}".format(epoch['valid_loss']))
             print("  validation accuracy:\t\t{:.2f} %%".format(

--- a/examples/mnist_conv_cc.py
+++ b/examples/mnist_conv_cc.py
@@ -111,8 +111,10 @@ def build_model(input_width, input_height, output_dim,
 
 
 def main(num_epochs=NUM_EPOCHS):
+    print("Loading data...")
     dataset = load_data()
 
+    print("Building model and compiling functions...")
     output_layer = build_model(
         input_height=dataset['input_height'],
         input_width=dataset['input_width'],

--- a/examples/mnist_conv_cc.py
+++ b/examples/mnist_conv_cc.py
@@ -128,11 +128,11 @@ def main(num_epochs=NUM_EPOCHS):
     print("Starting training...")
 
     for epoch in train(iter_funcs, dataset):
-        print("Epoch %d of %d" % (epoch['number'], num_epochs))
-        print("  training loss:\t\t%.6f" % epoch['train_loss'])
-        print("  validation loss:\t\t%.6f" % epoch['valid_loss'])
-        print("  validation accuracy:\t\t%.2f %%" %
-              (epoch['valid_accuracy'] * 100))
+        print("Epoch {} of {}".format(epoch['number'], num_epochs))
+        print("  training loss:\t\t{:.6f}".format(epoch['train_loss']))
+        print("  validation loss:\t\t{:.6f}".format(epoch['valid_loss']))
+        print("  validation accuracy:\t\t{:.2f} %%".format(
+              epoch['valid_accuracy'] * 100))
 
         if epoch['number'] >= num_epochs:
             break

--- a/examples/mnist_conv_dnn.py
+++ b/examples/mnist_conv_dnn.py
@@ -87,8 +87,10 @@ def build_model(input_width, input_height, output_dim,
 
 
 def main(num_epochs=NUM_EPOCHS):
+    print("Loading data...")
     dataset = load_data()
 
+    print("Building model and compiling functions...")
     output_layer = build_model(
         input_height=dataset['input_height'],
         input_width=dataset['input_width'],

--- a/examples/mnist_conv_dnn.py
+++ b/examples/mnist_conv_dnn.py
@@ -102,15 +102,19 @@ def main(num_epochs=NUM_EPOCHS):
     )
 
     print("Starting training...")
-    for epoch in train(iter_funcs, dataset):
-        print("Epoch {} of {}".format(epoch['number'], num_epochs))
-        print("  training loss:\t\t{:.6f}".format(epoch['train_loss']))
-        print("  validation loss:\t\t{:.6f}".format(epoch['valid_loss']))
-        print("  validation accuracy:\t\t{:.2f} %%".format(
-              epoch['valid_accuracy'] * 100))
+    try:
+        for epoch in train(iter_funcs, dataset):
+            print("Epoch {} of {}".format(epoch['number'], num_epochs))
+            print("  training loss:\t\t{:.6f}".format(epoch['train_loss']))
+            print("  validation loss:\t\t{:.6f}".format(epoch['valid_loss']))
+            print("  validation accuracy:\t\t{:.2f} %%".format(
+                epoch['valid_accuracy'] * 100))
 
-        if epoch['number'] >= num_epochs:
-            break
+            if epoch['number'] >= num_epochs:
+                break
+
+    except KeyboardInterrupt:
+        pass
 
     return output_layer
 

--- a/examples/mnist_conv_dnn.py
+++ b/examples/mnist_conv_dnn.py
@@ -4,6 +4,7 @@ import lasagne
 from lasagne.layers import dnn  # fails early if not available
 import theano
 import theano.tensor as T
+import time
 
 from mnist import _load_data
 from mnist import create_iter_functions
@@ -104,9 +105,12 @@ def main(num_epochs=NUM_EPOCHS):
     )
 
     print("Starting training...")
+    now = time.time()
     try:
         for epoch in train(iter_funcs, dataset):
-            print("Epoch {} of {}".format(epoch['number'], num_epochs))
+            print("Epoch {} of {} took {:.3f}s".format(
+                epoch['number'], num_epochs, time.time() - now))
+            now = time.time()
             print("  training loss:\t\t{:.6f}".format(epoch['train_loss']))
             print("  validation loss:\t\t{:.6f}".format(epoch['valid_loss']))
             print("  validation accuracy:\t\t{:.2f} %%".format(

--- a/examples/mnist_conv_dnn.py
+++ b/examples/mnist_conv_dnn.py
@@ -103,11 +103,11 @@ def main(num_epochs=NUM_EPOCHS):
 
     print("Starting training...")
     for epoch in train(iter_funcs, dataset):
-        print("Epoch %d of %d" % (epoch['number'], num_epochs))
-        print("  training loss:\t\t%.6f" % epoch['train_loss'])
-        print("  validation loss:\t\t%.6f" % epoch['valid_loss'])
-        print("  validation accuracy:\t\t%.2f %%" %
-              (epoch['valid_accuracy'] * 100))
+        print("Epoch {} of {}".format(epoch['number'], num_epochs))
+        print("  training loss:\t\t{:.6f}".format(epoch['train_loss']))
+        print("  validation loss:\t\t{:.6f}".format(epoch['valid_loss']))
+        print("  validation accuracy:\t\t{:.2f} %%".format(
+              epoch['valid_accuracy'] * 100))
 
         if epoch['number'] >= num_epochs:
             break


### PR DESCRIPTION
I was running the examples recently to compare the speed of Theano's convolutions (FFT and non-FFT), cudnn, and cuda_convnet, and in the process I made a few changes to the example files.  This PR reflects those changes, which are:

- Switched string syntax from `%` to `format`, because `%` are ["obsolete and may go away in future versions of Python"](https://docs.python.org/release/3.1.5/library/stdtypes.html#old-string-formatting-operations)
- Making it so that issuing ctrl-C while training just exits the script cleanly without a traceback (just an aesthetic thing when you don't want it to train for 500 epochs)
- Added print statements for loading data and building the models
- Added the amount of time each epoch took to the print statement

I can split these up if you want, or remove one of these changes if you want, but none of them really change the functionality in any big way.