### PR TITLE
Document variable `InputLayer` shape dimensions

### DIFF
--- a/lasagne/layers/input.py
+++ b/lasagne/layers/input.py
@@ -18,16 +18,24 @@ class InputLayer(Layer):
     created.
 
     :parameters:
-        - shape : tuple of int
-            The shape of the input
+        - shape : tuple of `int` or `None` elements
+            The shape of the input. Any element can be `None` to indicate
+            that the size of that dimension is not fixed at compile time.
 
-        - input_var : Theano symbolic variable or None (default: None)
+        - input_var : Theano symbolic variable or `None` (default: `None`)
             A variable representing a network input. If it is not provided,
             a variable will be created.
 
     :usage:
         >>> from lasagne.layers import InputLayer
         >>> l_in = InputLayer((100, 20))
+
+    :note:
+        The first dimension usually indicates the batch size. If you specify
+        it, Theano may apply more optimizations while compiling the training
+        or prediction function, but the compiled function will not accept
+        data of a different batch size at runtime. To compile for a variable
+        batch size, set the first shape element to `None` instead.
     """
     def __init__(self, shape, input_var=None, name=None, **kwargs):
         self.shape = shape


### PR DESCRIPTION
It wasn't documented that the `shape` of `InputLayer` may include `None`s, nor what that would be useful for.