### PR TITLE
Leaky rectifier nonlinearity

### DIFF
--- a/lasagne/nonlinearities.py
+++ b/lasagne/nonlinearities.py
@@ -20,6 +20,22 @@ def rectify(x):
     return (x + abs(x)) / 2.0
 
 
+# leaky rectify
+# Maas et al: Rectifier Nonlinearities Improve Neural Network Acoustic Models
+# http://web.stanford.edu/~awni/papers/relu_hybrid_icml2013_final.pdf
+class leaky_rectify(object):
+
+    def __init__(self, leakiness=0.01):
+        self.leakiness = leakiness
+
+    def __call__(self, x):
+        if self.leakiness:
+            import theano.tensor as T
+            return T.maximum(self.leakiness * x, x)
+        else:
+            return rectify(x)
+
+
 # linear
 def linear(x):
     return x

--- a/lasagne/nonlinearities.py
+++ b/lasagne/nonlinearities.py
@@ -13,11 +13,12 @@ from theano.tensor import tanh
 
 
 # rectify
-# The following is faster than lambda x: T.maximum(0, x)
-# Thanks to @SnippyHolloW for pointing this out.
-# See: https://github.com/SnippyHolloW/abnet/blob/807aeb9/layers.py#L15
 def rectify(x):
-    return (x + abs(x)) / 2.0
+    # The following is faster than T.maximum(0, x),
+    # and it works with nonsymbolic inputs as well.
+    # Thanks to @SnipyHollow for pointing this out. Also see:
+    # http://github.com/benanne/Lasagne/pull/163#issuecomment-81765117
+    return 0.5 * (x + abs(x))
 
 
 # leaky rectify
@@ -30,8 +31,12 @@ class LeakyRectify(object):
 
     def __call__(self, x):
         if self.leakiness:
-            import theano.tensor as T
-            return T.maximum(self.leakiness * x, x)
+            # The following is faster than T.maximum(leakiness * x, x),
+            # and it works with nonsymbolic inputs as well. Also see:
+            # http://github.com/benanne/Lasagne/pull/163#issuecomment-81765117
+            f1 = 0.5 * (1 + self.leakiness)
+            f2 = 0.5 * (1 - self.leakiness)
+            return f1 * x + f2 * abs(x)
         else:
             return rectify(x)
 

--- a/lasagne/nonlinearities.py
+++ b/lasagne/nonlinearities.py
@@ -23,7 +23,7 @@ def rectify(x):
 # leaky rectify
 # Maas et al: Rectifier Nonlinearities Improve Neural Network Acoustic Models
 # http://web.stanford.edu/~awni/papers/relu_hybrid_icml2013_final.pdf
-class leaky_rectify(object):
+class LeakyRectify(object):
 
     def __init__(self, leakiness=0.01):
         self.leakiness = leakiness
@@ -34,6 +34,9 @@ class leaky_rectify(object):
             return T.maximum(self.leakiness * x, x)
         else:
             return rectify(x)
+
+
+leaky_rectify = LeakyRectify()  # shortcut with default leakiness
 
 
 # linear

--- a/lasagne/tests/test_nonlinearities.py
+++ b/lasagne/tests/test_nonlinearities.py
@@ -8,8 +8,8 @@ def test_rectify():
 
 def test_leaky_rectify():
     from lasagne.nonlinearities import LeakyRectify
-    result = LeakyRectify(0.1)(np.array([-1, 0, 1, 2])).eval()
-    assert np.allclose(result, [-.1, 0, 1, 2])
+    lr = LeakyRectify(0.1)
+    assert np.allclose(lr(np.array([-1, 0, 1, 2])), [-.1, 0, 1, 2])
 
 
 def test_linear():

--- a/lasagne/tests/test_nonlinearities.py
+++ b/lasagne/tests/test_nonlinearities.py
@@ -1,6 +1,15 @@
+import numpy as np
+
+
 def test_rectify():
     from lasagne.nonlinearities import rectify
     assert [rectify(x) for x in (-1, 0, 1, 2)] == [0, 0, 1, 2]
+
+
+def test_leaky_rectify():
+    from lasagne.nonlinearities import leaky_rectify
+    result = leaky_rectify(0.1)(np.array([-1, 0, 1, 2])).eval()
+    assert np.allclose(result, [-.1, 0, 1, 2])
 
 
 def test_linear():

--- a/lasagne/tests/test_nonlinearities.py
+++ b/lasagne/tests/test_nonlinearities.py
@@ -7,8 +7,8 @@ def test_rectify():
 
 
 def test_leaky_rectify():
-    from lasagne.nonlinearities import leaky_rectify
-    result = leaky_rectify(0.1)(np.array([-1, 0, 1, 2])).eval()
+    from lasagne.nonlinearities import LeakyRectify
+    result = LeakyRectify(0.1)(np.array([-1, 0, 1, 2])).eval()
     assert np.allclose(result, [-.1, 0, 1, 2])
 
 


### PR DESCRIPTION
This adds the leaky rectifier nonlinearity with custom leakiness. Example use:
```python
input_var = theano.matrix('x')
layer = InputLayer((10, 20), input_var)
layer = DenseLayer(30, nonlinearity=lasagne.nonlinearities.leaky_rectify(0.05))
```

It's obviously a callable class, not a function. We can discuss whether to name it `leaky_rectify` to blend in with the others or `LeakyRectify` to set it apart. Thinking about it, I'm actually leaning towards the latter.