### PR TITLE
Added ReluNormal initializer from PReLU paper

### DIFF
--- a/lasagne/init.py
+++ b/lasagne/init.py
@@ -109,3 +109,25 @@ class Orthogonal(Initializer):
         q = u if u.shape == flat_shape else v
         q = q.reshape(shape)
         return floatX(self.gain * q)
+
+
+class ReluNormal(Initializer):
+    """
+    Initializer based on He et al, "Delving Deep into Rectifiers:
+        Surpassing Human-Level Performance on Imagenet Classification".
+    """
+
+    def __init__(self):
+        pass
+
+    def sample(self, shape):
+        if len(shape) < 2:
+            raise RuntimeError("Only shapes of length 2 or more are "
+                               "supported.")
+        # Same assumptions about meaning of different dimensions as Uniform.
+        # eg, for a Conv2D layer with spatial 5x5 dimensions this would be 25.
+        receptive_field_size = np.prod(shape[2:])
+        input_channels = shape[1]
+        n_l = input_channels*receptive_field_size
+        std = np.sqrt(2.0/(n_l))
+        return floatX(np.random.normal(0, std, size=shape))

--- a/lasagne/tests/test_init.py
+++ b/lasagne/tests/test_init.py
@@ -101,3 +101,10 @@ def test_orthogonal_1d_not_supported():
 
     with pytest.raises(RuntimeError):
         Orthogonal().sample((100,))
+
+
+def test_relu_normal():
+    from lasagne.init import ReluNormal
+
+    sample = ReluNormal().sample((100, 200))
+    assert sample.shape == (100, 200)


### PR DESCRIPTION
Hi, this is the initialization scheme they use in the parametric ReLU paper. If there's interest I could add more tests. I wasn't sure about the name, I chose this once since the idea is that it's for convolutional layers with ReLU units and it's a normal. 