### PR TITLE
Make Conv layers support None in input shape

### DIFF
--- a/lasagne/layers/conv.py
+++ b/lasagne/layers/conv.py
@@ -15,6 +15,8 @@ __all__ = [
 
 def conv_output_length(input_length, filter_length,
                        stride, border_mode, pad=0):
+    if input_length is None:
+        return None
     if border_mode == 'valid':
         output_length = input_length - filter_length + 1
     elif border_mode == 'full':
@@ -103,7 +105,7 @@ class Conv1DLayer(Layer):
                                       filter_shape=filter_shape,
                                       border_mode='full')
             shift = (self.filter_length - 1) // 2
-            conved = conved[:, :, shift:input_shape[2] + shift]
+            conved = conved[:, :, shift:input.shape[2] + shift]
         else:
             raise RuntimeError("Invalid border mode: '%s'" % self.border_mode)
 
@@ -194,8 +196,8 @@ class Conv2DLayer(Layer):
                                       border_mode='full')
             shift_x = (self.filter_size[0] - 1) // 2
             shift_y = (self.filter_size[1] - 1) // 2
-            conved = conved[:, :, shift_x:input_shape[2] + shift_x,
-                            shift_y:input_shape[3] + shift_y]
+            conved = conved[:, :, shift_x:input.shape[2] + shift_x,
+                            shift_y:input.shape[3] + shift_y]
         else:
             raise RuntimeError("Invalid border mode: '%s'" % self.border_mode)
 

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -9,6 +9,8 @@ from .. import nonlinearities
 
 from .base import Layer
 
+from .conv import conv_output_length
+
 from theano.sandbox.cuda.basic_ops import gpu_contiguous
 from theano.sandbox.cuda.blas import GpuCorrMM
 
@@ -93,11 +95,17 @@ class Conv2DMMLayer(MMLayer):
 
     def get_output_shape_for(self, input_shape):
         batch_size = input_shape[0]
-        input_rows, input_columns = input_shape[2:4]
-        output_rows = ((input_rows + 2*self.pad[0] - self.filter_size[0]) //
-                       self.strides[0] + 1)
-        output_columns = ((input_columns + 2*self.pad[1] -
-                           self.filter_size[1]) // self.strides[1] + 1)
+
+        output_rows = conv_output_length(input_shape[2],
+                                         self.filter_size[0],
+                                         self.strides[0],
+                                         'pad', self.pad[0])
+
+        output_columns = conv_output_length(input_shape[3],
+                                            self.filter_size[1],
+                                            self.strides[1],
+                                            'pad', self.pad[1])
+
         return (batch_size, self.num_filters, output_rows, output_columns)
 
     def get_output_for(self, input, *args, **kwargs):

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -6,6 +6,7 @@ from .. import nonlinearities
 
 from .base import Layer
 
+from .conv import conv_output_length
 
 if not theano.config.device.startswith("gpu") or not dnn.dnn_available():
     raise ImportError("dnn not available")
@@ -119,11 +120,17 @@ class Conv2DDNNLayer(DNNLayer):
 
     def get_output_shape_for(self, input_shape):
         batch_size = input_shape[0]
-        input_rows, input_columns = input_shape[2:4]
-        output_rows = ((input_rows + 2*self.pad[0] - self.filter_size[0]) //
-                       self.strides[0] + 1)
-        output_columns = (input_columns + 2*self.pad[1] -
-                          self.filter_size[1]) // self.strides[1] + 1
+
+        output_rows = conv_output_length(input_shape[2],
+                                         self.filter_size[0],
+                                         self.strides[0],
+                                         'pad', self.pad[0])
+
+        output_columns = conv_output_length(input_shape[3],
+                                            self.filter_size[1],
+                                            self.strides[1],
+                                            'pad', self.pad[1])
+
         return (batch_size, self.num_filters, output_rows, output_columns)
 
     def get_output_for(self, input, *args, **kwargs):


### PR DESCRIPTION
Adds test coverage of `None` in the b01 dimensions of Conv layers, and updates those that needed fixes to support it.

This partially resolves https://github.com/benanne/Lasagne/issues/166, although it needs to be documented somewhere that this is the proper way to handle variable input size, since until https://github.com/Theano/Theano/issues/2620 is fixed, it will still be possible to get results of the wrong shape without an error.