### PR TITLE
Remove *args from get_output() and get_output_for()

### DIFF
--- a/lasagne/layers/base.py
+++ b/lasagne/layers/base.py
@@ -91,7 +91,7 @@ class Layer(object):
         """
         return self.get_output_shape_for(self.input_shape)
 
-    def get_output(self, input=None, *args, **kwargs):
+    def get_output(self, input=None, **kwargs):
         """
         Computes the output of the network at this layer. Optionally, you can
         define an input to propagate through the network instead of using the
@@ -125,8 +125,8 @@ class Layer(object):
                                "there isn't anything to get its input from. "
                                "Did you mean get_output_for()?")
         else:  # in all other cases, just pass the input on to the next layer.
-            layer_input = self.input_layer.get_output(input, *args, **kwargs)
-            return self.get_output_for(layer_input, *args, **kwargs)
+            layer_input = self.input_layer.get_output(input, **kwargs)
+            return self.get_output_for(layer_input, **kwargs)
 
     def get_output_shape_for(self, input_shape):
         """
@@ -153,7 +153,7 @@ class Layer(object):
         """
         return input_shape
 
-    def get_output_for(self, input, *args, **kwargs):
+    def get_output_for(self, input, **kwargs):
         """
         Propagates the given input through this layer (and only this layer).
 
@@ -272,7 +272,7 @@ class MultipleInputsLayer(Layer):
     def get_output_shape(self):
         return self.get_output_shape_for(self.input_shapes)
 
-    def get_output(self, input=None, *args, **kwargs):
+    def get_output(self, input=None, **kwargs):
         if isinstance(input, dict) and (self in input):
             # this layer is mapped to an expression or numpy array
             return utils.as_theano_expression(input[self])
@@ -282,9 +282,9 @@ class MultipleInputsLayer(Layer):
                                "Did you mean get_output_for()?")
         # In all other cases, just pass the network input on to the next layers
         else:
-            layer_inputs = [input_layer.get_output(input, *args, **kwargs) for
+            layer_inputs = [input_layer.get_output(input, **kwargs) for
                             input_layer in self.input_layers]
-            return self.get_output_for(layer_inputs, *args, **kwargs)
+            return self.get_output_for(layer_inputs, **kwargs)
 
     def get_output_shape_for(self, input_shapes):
         """
@@ -310,7 +310,7 @@ class MultipleInputsLayer(Layer):
         """
         raise NotImplementedError
 
-    def get_output_for(self, inputs, *args, **kwargs):
+    def get_output_for(self, inputs, **kwargs):
         """
         Propagates the given inputs through this layer (and only this layer).
 

--- a/lasagne/layers/conv.py
+++ b/lasagne/layers/conv.py
@@ -81,7 +81,7 @@ class Conv1DLayer(Layer):
 
         return (input_shape[0], self.num_filters, output_length)
 
-    def get_output_for(self, input, input_shape=None, *args, **kwargs):
+    def get_output_for(self, input, input_shape=None, **kwargs):
         # the optional input_shape argument is for when get_output_for is
         # called directly with a different shape than self.input_shape.
         if input_shape is None:
@@ -171,7 +171,7 @@ class Conv2DLayer(Layer):
 
         return (input_shape[0], self.num_filters, output_rows, output_columns)
 
-    def get_output_for(self, input, input_shape=None, *args, **kwargs):
+    def get_output_for(self, input, input_shape=None, **kwargs):
         # the optional input_shape argument is for when get_output_for is
         # called directly with a different shape than self.input_shape.
         if input_shape is None:

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -108,7 +108,7 @@ class Conv2DMMLayer(MMLayer):
 
         return (batch_size, self.num_filters, output_rows, output_columns)
 
-    def get_output_for(self, input, *args, **kwargs):
+    def get_output_for(self, input, **kwargs):
         filters = self.W
         if self.flip_filters:
             filters = filters[:, :, ::-1, ::-1]  # flip top-down, left-right

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -149,7 +149,7 @@ class Conv2DCCLayer(CCLayer):
         else:
             return (self.num_filters, output_rows, output_columns, batch_size)
 
-    def get_output_for(self, input, *args, **kwargs):
+    def get_output_for(self, input, **kwargs):
         if self.dimshuffle:
             filters = self.W.dimshuffle(1, 2, 3, 0)  # bc01 to c01b
             input = input.dimshuffle(1, 2, 3, 0)  # bc01 to c01b
@@ -243,7 +243,7 @@ class MaxPool2DCCLayer(CCLayer):
             return (num_input_channels, output_rows, output_columns,
                     batch_size)
 
-    def get_output_for(self, input, *args, **kwargs):
+    def get_output_for(self, input, **kwargs):
         if self.dimshuffle:
             input = input.dimshuffle(1, 2, 3, 0)  # bc01 to c01b
 
@@ -271,7 +271,7 @@ class ShuffleBC01ToC01BLayer(Layer):
     def get_output_shape_for(self, input_shape):
         return (input_shape[1], input_shape[2], input_shape[3], input_shape[0])
 
-    def get_output_for(self, input, *args, **kwargs):
+    def get_output_for(self, input, **kwargs):
         return input.dimshuffle(1, 2, 3, 0)
 
 bc01_to_c01b = ShuffleBC01ToC01BLayer  # shortcut
@@ -286,7 +286,7 @@ class ShuffleC01BToBC01Layer(Layer):
     def get_output_shape_for(self, input_shape):
         return (input_shape[3], input_shape[0], input_shape[1], input_shape[2])
 
-    def get_output_for(self, input, *args, **kwargs):
+    def get_output_for(self, input, **kwargs):
         return input.dimshuffle(3, 0, 1, 2)
 
 c01b_to_bc01 = ShuffleC01BToBC01Layer  # shortcut
@@ -332,7 +332,7 @@ class NINLayer_c01b(Layer):
     def get_output_shape_for(self, input_shape):
         return (self.num_units,) + input_shape[1:]
 
-    def get_output_for(self, input, *args, **kwargs):
+    def get_output_for(self, input, **kwargs):
         # fc * c01b... = f01b...
         out = T.tensordot(self.W, input, axes=[[1], [0]])
 

--- a/lasagne/layers/dense.py
+++ b/lasagne/layers/dense.py
@@ -77,7 +77,7 @@ class DenseLayer(Layer):
     def get_output_shape_for(self, input_shape):
         return (input_shape[0], self.num_units)
 
-    def get_output_for(self, input, *args, **kwargs):
+    def get_output_for(self, input, **kwargs):
         if input.ndim > 2:
             # if the input has more than two dimensions, flatten it into a
             # batch of feature vectors.
@@ -131,7 +131,7 @@ class NINLayer(Layer):
     def get_output_shape_for(self, input_shape):
         return (input_shape[0], self.num_units) + input_shape[2:]
 
-    def get_output_for(self, input, *args, **kwargs):
+    def get_output_for(self, input, **kwargs):
         # cf * bc01... = fb01...
         out_r = T.tensordot(self.W, input, axes=[[0], [1]])
         # input dims to broadcast over

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -36,7 +36,7 @@ class Pool2DDNNLayer(DNNLayer):
         output_shape[3] = (output_shape[3] - self.ds[1]) // self.strides[1] + 1
         return tuple(output_shape)
 
-    def get_output_for(self, input, *args, **kwargs):
+    def get_output_for(self, input, **kwargs):
         return dnn.dnn_pool(input, self.ds, self.strides, self.mode)
 
 
@@ -133,7 +133,7 @@ class Conv2DDNNLayer(DNNLayer):
 
         return (batch_size, self.num_filters, output_rows, output_columns)
 
-    def get_output_for(self, input, *args, **kwargs):
+    def get_output_for(self, input, **kwargs):
         # by default we assume 'cross', consistent with corrmm.
         conv_mode = 'conv' if self.flip_filters else 'cross'
         # if 'border_mode' is one of 'valid' or 'full' use that.

--- a/lasagne/layers/input.py
+++ b/lasagne/layers/input.py
@@ -56,7 +56,7 @@ class InputLayer(Layer):
     def get_output_shape(self):
         return self.shape
 
-    def get_output(self, input=None, *args, **kwargs):
+    def get_output(self, input=None, **kwargs):
         if isinstance(input, dict):
             input = input.get(self, None)
         if input is None:

--- a/lasagne/layers/merge.py
+++ b/lasagne/layers/merge.py
@@ -21,7 +21,7 @@ class ConcatLayer(MultipleInputsLayer):
         output_shape[self.axis] = sum(sizes)
         return tuple(output_shape)
 
-    def get_output_for(self, inputs, *args, **kwargs):
+    def get_output_for(self, inputs, **kwargs):
         return T.concatenate(inputs, axis=self.axis)
 
 concat = ConcatLayer  # shortcut
@@ -66,7 +66,7 @@ class ElemwiseSumLayer(MultipleInputsLayer):
             raise ValueError("Mismatch: not all input shapes are the same")
         return input_shapes[0]
 
-    def get_output_for(self, inputs, *args, **kwargs):
+    def get_output_for(self, inputs, **kwargs):
         output = None
         for coeff, input in zip(self.coeffs, inputs):
             if coeff != 1:

--- a/lasagne/layers/noise.py
+++ b/lasagne/layers/noise.py
@@ -20,7 +20,7 @@ class DropoutLayer(Layer):
         self.p = p
         self.rescale = rescale
 
-    def get_output_for(self, input, deterministic=False, *args, **kwargs):
+    def get_output_for(self, input, deterministic=False, **kwargs):
         if deterministic or self.p == 0:
             return input
         else:
@@ -44,7 +44,7 @@ class GaussianNoiseLayer(Layer):
         super(GaussianNoiseLayer, self).__init__(incoming, **kwargs)
         self.sigma = sigma
 
-    def get_output_for(self, input, deterministic=False, *args, **kwargs):
+    def get_output_for(self, input, deterministic=False, **kwargs):
         if deterministic or self.sigma == 0:
             return input
         else:

--- a/lasagne/layers/normalization.py
+++ b/lasagne/layers/normalization.py
@@ -86,7 +86,7 @@ class LocalResponseNormalization2DLayer(Layer):
     def get_output_shape_for(self, input_shape):
         return input_shape
 
-    def get_output_for(self, input, *args, **kwargs):
+    def get_output_for(self, input, **kwargs):
         input_shape = self.input_shape
         if any(s is None for s in input_shape):
             input_shape = input.shape

--- a/lasagne/layers/pool.py
+++ b/lasagne/layers/pool.py
@@ -36,7 +36,7 @@ class MaxPool2DLayer(Layer):
 
         return tuple(output_shape)
 
-    def get_output_for(self, input, *args, **kwargs):
+    def get_output_for(self, input, **kwargs):
         return downsample.max_pool_2d(input, self.ds, self.ignore_border)
 
 
@@ -74,7 +74,7 @@ class FeaturePoolLayer(Layer):
         output_shape[self.axis] = output_shape[self.axis] // self.ds
         return tuple(output_shape)
 
-    def get_output_for(self, input, *args, **kwargs):
+    def get_output_for(self, input, **kwargs):
         num_feature_maps = input.shape[self.axis]
         num_feature_maps_out = num_feature_maps // self.ds
 
@@ -113,7 +113,7 @@ class FeatureWTALayer(Layer):
                                "multiple of the group size (ds=%d)" %
                                (num_feature_maps, self.ds))
 
-    def get_output_for(self, input, *args, **kwargs):
+    def get_output_for(self, input, **kwargs):
         num_feature_maps = input.shape[self.axis]
         num_pools = num_feature_maps // self.ds
 
@@ -151,5 +151,5 @@ class GlobalPoolLayer(Layer):
     def get_output_shape_for(self, input_shape):
         return input_shape[:2]
 
-    def get_output_for(self, input, *args, **kwargs):
+    def get_output_for(self, input, **kwargs):
         return self.pool_function(input.flatten(3), axis=2)

--- a/lasagne/layers/shape.py
+++ b/lasagne/layers/shape.py
@@ -21,7 +21,7 @@ class FlattenLayer(Layer):
     def get_output_shape_for(self, input_shape):
         return (input_shape[0], int(np.prod(input_shape[1:])))
 
-    def get_output_for(self, input, *args, **kwargs):
+    def get_output_for(self, input, **kwargs):
         return input.flatten(2)
 
 flatten = FlattenLayer  # shortcut
@@ -80,7 +80,7 @@ class ReshapeLayer(Layer):
             raise ValueError("`shape` cannot contain multiple -1")
         self.shape = shape
 
-    def get_output_shape_for(self, input_shape, *args, **kwargs):
+    def get_output_shape_for(self, input_shape, **kwargs):
         # Initialize output shape from shape specification
         output_shape = list(self.shape)
         # First, replace all `[i]` with the corresponding input dimension, and
@@ -127,7 +127,7 @@ class ReshapeLayer(Layer):
                              (input_shape, self.shape))
         return tuple(output_shape)
 
-    def get_output_for(self, input, *args, **kwargs):
+    def get_output_for(self, input, **kwargs):
         # Replace all `[i]` with the corresponding input dimension
         output_shape = list(self.shape)
         for dim, o in enumerate(output_shape):
@@ -226,7 +226,7 @@ class DimshuffleLayer(Layer):
 
         return tuple(output_shape)
 
-    def get_output_for(self, input, *args, **kwargs):
+    def get_output_for(self, input, **kwargs):
         return input.dimshuffle(self.pattern)
 
 dimshuffle = DimshuffleLayer  # shortcut
@@ -249,7 +249,7 @@ class PadLayer(Layer):
 
         return output_shape
 
-    def get_output_for(self, input, *args, **kwargs):
+    def get_output_for(self, input, **kwargs):
         return padding.pad(input, self.width, self.val, self.batch_ndim)
 
 pad = PadLayer  # shortcut

--- a/lasagne/objectives.py
+++ b/lasagne/objectives.py
@@ -50,8 +50,7 @@ class Objective(object):
                              'or None, not {0}'.format(aggregation))
         self.aggregation = aggregation
 
-    def get_loss(self, input=None, target=None, aggregation=None,
-                 *args, **kwargs):
+    def get_loss(self, input=None, target=None, aggregation=None, **kwargs):
         """
         Get loss scalar expression
 
@@ -63,15 +62,13 @@ class Objective(object):
                 given the input
             - aggregation : None to use the value passed to the
                 constructor or a value to override it
-            - args : additional arguments passed to `input_layer`'s
-                `get_output` method
             - kwargs : additional keyword arguments passed to `input_layer`'s
                 `get_output` method
 
         :returns:
             - output : loss expressions
         """
-        network_output = self.input_layer.get_output(input, *args, **kwargs)
+        network_output = self.input_layer.get_output(input, **kwargs)
         if target is None:
             target = self.target_var
         if aggregation not in self._valid_aggregation:
@@ -130,7 +127,7 @@ class MaskedObjective(object):
         self.aggregation = aggregation
 
     def get_loss(self, input=None, target=None, mask=None,
-                 aggregation=None, *args, **kwargs):
+                 aggregation=None, **kwargs):
         """
         Get loss scalar expression
 
@@ -146,15 +143,13 @@ class MaskedObjective(object):
                 contributions of the resulting loss values
             - aggregation : None to use the value passed to the
                 constructor or a value to override it
-            - args : additional arguments passed to `input_layer`'s
-                `get_output` method
             - kwargs : additional keyword arguments passed to `input_layer`'s
                 `get_output` method
 
         :returns:
             - output : loss expressions
         """
-        network_output = self.input_layer.get_output(input, *args, **kwargs)
+        network_output = self.input_layer.get_output(input, **kwargs)
         if target is None:
             target = self.target_var
         if mask is None:

--- a/lasagne/tests/layers/test_base.py
+++ b/lasagne/tests/layers/test_base.py
@@ -26,15 +26,15 @@ class TestLayer:
         layer.input_layer.get_output.assert_called_with(None)
 
     def test_get_output_passes_on_arguments_to_input_layer(self, layer):
-        input, arg, kwarg = object(), object(), object()
+        input, kwarg = object(), object()
         layer.get_output_for = Mock()
 
-        output = layer.get_output(input, arg, kwarg=kwarg)
+        output = layer.get_output(input, kwarg=kwarg)
         assert output is layer.get_output_for.return_value
         layer.get_output_for.assert_called_with(
-            layer.input_layer.get_output.return_value, arg, kwarg=kwarg)
+            layer.input_layer.get_output.return_value, kwarg=kwarg)
         layer.input_layer.get_output.assert_called_with(
-            input, arg, kwarg=kwarg)
+            input, kwarg=kwarg)
 
     def test_get_output_input_is_a_mapping(self, layer):
         input = {layer: theano.tensor.matrix()}
@@ -140,19 +140,19 @@ class TestMultipleInputsLayer:
         layer.input_layers[1].get_output.assert_called_with(None)
 
     def test_get_output_passes_on_arguments_to_input_layer(self, layer):
-        input, arg, kwarg = object(), object(), object()
+        input, kwarg = object(), object()
         layer.get_output_for = Mock()
 
-        output = layer.get_output(input, arg, kwarg=kwarg)
+        output = layer.get_output(input, kwarg=kwarg)
         assert output is layer.get_output_for.return_value
         layer.get_output_for.assert_called_with([
             layer.input_layers[0].get_output.return_value,
             layer.input_layers[1].get_output.return_value,
-            ], arg, kwarg=kwarg)
+            ], kwarg=kwarg)
         layer.input_layers[0].get_output.assert_called_with(
-            input, arg, kwarg=kwarg)
+            input, kwarg=kwarg)
         layer.input_layers[1].get_output.assert_called_with(
-            input, arg, kwarg=kwarg)
+            input, kwarg=kwarg)
 
     def test_get_output_input_is_a_mapping(self, layer):
         input = {layer: theano.tensor.matrix()}

--- a/lasagne/tests/test_objectives.py
+++ b/lasagne/tests/test_objectives.py
@@ -178,15 +178,14 @@ class TestObjectives:
 
         input_layer = mock.Mock()
         loss_function = mock.Mock()
-        input, target, arg1, kwarg1 = object(), object(), object(), object()
+        input, target, kwarg1 = object(), object(), object()
         objective = Objective(input_layer, loss_function)
-        result = objective.get_loss(input, target, 'mean', arg1,
-                                    kwarg1=kwarg1)
+        result = objective.get_loss(input, target, 'mean', kwarg1=kwarg1)
 
         # We expect that the input layer's `get_output` was called with
         # the `input` argument we provided, plus the extra positional and
         # keyword arguments.
-        input_layer.get_output.assert_called_with(input, arg1, kwarg1=kwarg1)
+        input_layer.get_output.assert_called_with(input, kwarg1=kwarg1)
         network_output = input_layer.get_output.return_value
 
         # The `network_output` and `target` are fed into the loss


### PR DESCRIPTION
This removes `*args` from `get_output()` and `get_output_for()`, leaving only `**kwargs` for customizations.

@benanne stated that the `*args` [were there intentionally](https://github.com/benanne/Lasagne/issues/115#issuecomment-71394148), but without an existing use case. Later in the same thread we established that we should not include `*args` [for the layer constructor](https://github.com/benanne/Lasagne/issues/115#issuecomment-71466435) to avoid people writing code that can break in future (or, put differently, to allow us to add additional arguments without breaking people's existing code).

In any case, please see this as a proposal to be discussed rather than a request to be merged, it just took 5 minutes.