### PR TITLE
Topological order for get_all_layers()

### DIFF
--- a/lasagne/tests/layers/test_helper.py
+++ b/lasagne/tests/layers/test_helper.py
@@ -1,0 +1,67 @@
+import pytest
+import theano
+
+
+import lasagne
+
+
+class TestGetAllLayers:
+    def test_stack(self):
+        from lasagne.layers import InputLayer, DenseLayer, get_all_layers
+        from itertools import permutations
+        # l1 --> l2 --> l3
+        l1 = InputLayer((10, 20))
+        l2 = DenseLayer(l1, 30)
+        l3 = DenseLayer(l2, 40)
+        for count in (0, 1, 2, 3):
+            for query in permutations([l1, l2, l3], count):
+                if l3 in query:
+                    expected = [l1, l2, l3]
+                elif l2 in query:
+                    expected = [l1, l2]
+                elif l1 in query:
+                    expected = [l1]
+                else:
+                    expected = []
+                assert get_all_layers(query) == expected
+
+    def test_merge(self):
+        from lasagne.layers import (InputLayer, DenseLayer, ElemwiseSumLayer,
+                                    get_all_layers)
+        # l1 --> l2 --> l3 --> l6
+        #        l4 --> l5 ----^
+        l1 = InputLayer((10, 20))
+        l2 = DenseLayer(l1, 30)
+        l3 = DenseLayer(l2, 40)
+        l4 = InputLayer((10, 30))
+        l5 = DenseLayer(l4, 40)
+        l6 = ElemwiseSumLayer([l3, l5])
+        assert get_all_layers(l6) == [l1, l2, l3, l4, l5, l6]
+        assert get_all_layers([l4, l6]) == [l4, l1, l2, l3, l5, l6]
+        assert get_all_layers([l5, l6]) == [l4, l5, l1, l2, l3, l6]
+        assert get_all_layers([l4, l2, l5, l6]) == [l4, l1, l2, l5, l3, l6]
+
+    def test_split(self):
+        from lasagne.layers import InputLayer, DenseLayer, get_all_layers
+        # l1 --> l2 --> l3
+        #  \---> l4
+        l1 = InputLayer((10, 20))
+        l2 = DenseLayer(l1, 30)
+        l3 = DenseLayer(l2, 40)
+        l4 = DenseLayer(l1, 50)
+        assert get_all_layers(l3) == [l1, l2, l3]
+        assert get_all_layers(l4) == [l1, l4]
+        assert get_all_layers([l3, l4]) == [l1, l2, l3, l4]
+        assert get_all_layers([l4, l3]) == [l1, l4, l2, l3]
+
+    def test_bridge(self):
+        from lasagne.layers import (InputLayer, DenseLayer, ElemwiseSumLayer,
+                                    get_all_layers)
+        # l1 --> l2 --> l3 --> l4 --> l5
+        #         \------------^
+        l1 = InputLayer((10, 20))
+        l2 = DenseLayer(l1, 30)
+        l3 = DenseLayer(l2, 30)
+        l4 = ElemwiseSumLayer([l2, l3])
+        l5 = DenseLayer(l4, 40)
+        assert get_all_layers(l5) == [l1, l2, l3, l4, l5]


### PR DESCRIPTION
This renames the current implementation of `lasagne.layers.get_all_layers()` to `lasagne.layers.get_all_layers_old()` and installs a new implementation `lasagne.layers.get_all_layers()` which is guaranteed (and tested) to return layers in topological order. This is a requirement for #104, among others.

It currently gives a warning whenever it is called, along with a note on how to disable that. The warning serves to notify all users of the transition and `get_all_layers_old()` eases it, but both should be removed for the first release of Lasagne.