### PR TITLE
Revamp lasagne.init

### DIFF
--- a/examples/mnist_conv.py
+++ b/examples/mnist_conv.py
@@ -54,7 +54,7 @@ def build_model(input_width, input_height, output_dim,
         num_filters=32,
         filter_size=(5, 5),
         nonlinearity=lasagne.nonlinearities.rectify,
-        W=lasagne.init.Uniform(),
+        W=lasagne.init.GlorotUniform(),
         )
     l_pool1 = lasagne.layers.MaxPool2DLayer(l_conv1, ds=(2, 2))
 
@@ -63,7 +63,7 @@ def build_model(input_width, input_height, output_dim,
         num_filters=32,
         filter_size=(5, 5),
         nonlinearity=lasagne.nonlinearities.rectify,
-        W=lasagne.init.Uniform(),
+        W=lasagne.init.GlorotUniform(),
         )
     l_pool2 = lasagne.layers.MaxPool2DLayer(l_conv2, ds=(2, 2))
 
@@ -71,7 +71,7 @@ def build_model(input_width, input_height, output_dim,
         l_pool2,
         num_units=256,
         nonlinearity=lasagne.nonlinearities.rectify,
-        W=lasagne.init.Uniform(),
+        W=lasagne.init.GlorotUniform(),
         )
 
     l_hidden1_dropout = lasagne.layers.DropoutLayer(l_hidden1, p=0.5)
@@ -87,7 +87,7 @@ def build_model(input_width, input_height, output_dim,
         l_hidden1_dropout,
         num_units=output_dim,
         nonlinearity=lasagne.nonlinearities.softmax,
-        W=lasagne.init.Uniform(),
+        W=lasagne.init.GlorotUniform(),
         )
 
     return l_out

--- a/examples/mnist_conv_cc.py
+++ b/examples/mnist_conv_cc.py
@@ -59,7 +59,6 @@ def build_model(input_width, input_height, output_dim,
         num_filters=32,
         filter_size=(5, 5),
         nonlinearity=lasagne.nonlinearities.rectify,
-        W=lasagne.init.Uniform(),
         dimshuffle=dimshuffle,
     )
     l_pool1 = cuda_convnet.MaxPool2DCCLayer(
@@ -73,7 +72,6 @@ def build_model(input_width, input_height, output_dim,
         num_filters=32,
         filter_size=(5, 5),
         nonlinearity=lasagne.nonlinearities.rectify,
-        W=lasagne.init.Uniform(),
         dimshuffle=dimshuffle,
     )
     l_pool2 = cuda_convnet.MaxPool2DCCLayer(
@@ -89,7 +87,6 @@ def build_model(input_width, input_height, output_dim,
         l_pool2,
         num_units=256,
         nonlinearity=lasagne.nonlinearities.rectify,
-        W=lasagne.init.Uniform(),
     )
 
     l_hidden1_dropout = lasagne.layers.DropoutLayer(l_hidden1, p=0.5)
@@ -105,7 +102,6 @@ def build_model(input_width, input_height, output_dim,
         l_hidden1_dropout,
         num_units=output_dim,
         nonlinearity=lasagne.nonlinearities.softmax,
-        W=lasagne.init.Uniform(),
     )
 
     return l_out

--- a/examples/mnist_conv_dnn.py
+++ b/examples/mnist_conv_dnn.py
@@ -55,7 +55,7 @@ def build_model(input_width, input_height, output_dim,
         num_filters=32,
         filter_size=(5, 5),
         nonlinearity=lasagne.nonlinearities.rectify,
-        W=lasagne.init.Uniform(),
+        W=lasagne.init.GlorotUniform(),
     )
     l_pool1 = dnn.MaxPool2DDNNLayer(l_conv1, ds=(2, 2))
 
@@ -64,7 +64,7 @@ def build_model(input_width, input_height, output_dim,
         num_filters=32,
         filter_size=(5, 5),
         nonlinearity=lasagne.nonlinearities.rectify,
-        W=lasagne.init.Uniform(),
+        W=lasagne.init.GlorotUniform(),
     )
     l_pool2 = dnn.MaxPool2DDNNLayer(l_conv2, ds=(2, 2))
 
@@ -72,7 +72,7 @@ def build_model(input_width, input_height, output_dim,
         l_pool2,
         num_units=256,
         nonlinearity=lasagne.nonlinearities.rectify,
-        W=lasagne.init.Uniform(),
+        W=lasagne.init.GlorotUniform(),
     )
 
     l_hidden1_dropout = lasagne.layers.DropoutLayer(l_hidden1, p=0.5)
@@ -81,7 +81,7 @@ def build_model(input_width, input_height, output_dim,
         l_hidden1_dropout,
         num_units=output_dim,
         nonlinearity=lasagne.nonlinearities.softmax,
-        W=lasagne.init.Uniform(),
+        W=lasagne.init.GlorotUniform(),
     )
 
     return l_out

--- a/lasagne/init.py
+++ b/lasagne/init.py
@@ -2,8 +2,6 @@
 Functions to create initializers for parameter variables
 """
 
-from numbers import Number
-
 import numpy as np
 
 from .utils import floatX
@@ -38,11 +36,13 @@ class Uniform(Initializer):
         if std is not None:
             a = mean - np.sqrt(3) * std
             b = mean + np.sqrt(3) * std
-            self.range = (a, b)
-        elif isinstance(range, Number):
-            self.range = (-range, range)
         else:
-            self.range = range
+            try:
+                a, b = range  # range is a tuple
+            except TypeError:
+                a, b = -range, range  # range is a number
+
+        self.range = (a, b)
 
     def sample(self, shape):
         return floatX(np.random.uniform(

--- a/lasagne/init.py
+++ b/lasagne/init.py
@@ -26,6 +26,85 @@ class Normal(Initializer):
         return floatX(np.random.normal(self.avg, self.std, size=shape))
 
 
+class GlorotNormal(Normal):
+    def __init__(self, gain=1.0):
+        if gain == 'relu':
+            gain = np.sqrt(2)
+
+        self.gain = gain
+
+    def sample(self, shape):
+        # This code makes some assumptions about the meanings of
+        # the different dimensions, which hold for
+        # layers.DenseLayer and layers.Conv*DLayer, but not
+        # necessarily for other layer types.
+        n1, n2 = shape[:2]
+        receptive_field_size = np.prod(shape[2:])
+        std = self.gain * np.sqrt(2.0 / ((n1 + n2) * receptive_field_size))
+        return floatX(np.random.normal(0.0, std, size=shape))
+
+
+class GlorotNormal_c01b(GlorotNormal):
+    def sample(self, shape):
+        if len(shape) != 4:
+            raise RuntimeError(
+                "This initializer only works with shapes of length 4")
+
+        n1, n2 = shape[0], shape[3]
+        receptive_field_size = shape[1] * shape[2]
+        std = self.gain * np.sqrt(2.0 / ((n1 + n2) * receptive_field_size))
+        return floatX(np.random.normal(0.0, std, size=shape))
+
+
+class Uniform(Initializer):
+    def __init__(self, range=0.01):
+        import warnings
+        warnings.warn("The uniform initializer no longer uses Glorot et al.'s "
+                      "approach to determine the bounds, but defaults to the "
+                      "range (-0.01, 0.01) instead. Please use the new "
+                      "GlorotUniform initializer to get the old behavior. "
+                      "GlorotUniform is now the default for all layers.")
+
+        if isinstance(range, Number):
+            self.range = (-range, range)
+        else:
+            self.range = range
+
+    def sample(self, shape):
+        return floatX(np.random.uniform(
+            low=self.range[0], high=self.range[1], size=shape))
+
+
+class GlorotUniform(Uniform):
+    def __init__(self, gain=1.0):
+        if gain == 'relu':
+            gain = np.sqrt(2)
+
+        self.gain = gain
+
+    def sample(self, shape):
+        # This code makes some assumptions about the meanings of
+        # the different dimensions, which hold for
+        # layers.DenseLayer and layers.Conv*DLayer, but not
+        # necessarily for other layer types.
+        n1, n2 = shape[:2]
+        receptive_field_size = np.prod(shape[2:])
+        m = self.gain * np.sqrt(6.0 / ((n1 + n2) * receptive_field_size))
+        return floatX(np.random.uniform(low=-m, high=m, size=shape))
+
+
+class GlorotUniform_c01b(GlorotUniform):
+    def sample(self, shape):
+        if len(shape) != 4:
+            raise RuntimeError(
+                "This initializer only works with shapes of length 4")
+
+        n1, n2 = shape[0], shape[3]
+        receptive_field_size = shape[1] * shape[2]
+        m = self.gain * np.sqrt(6.0 / ((n1 + n2) * receptive_field_size))
+        return floatX(np.random.uniform(low=-m, high=m, size=shape))
+
+
 class Constant(Initializer):
     def __init__(self, val=0.0):
         self.val = val
@@ -56,32 +135,6 @@ class Sparse(Initializer):
             w[indices, k] = values
 
         return w
-
-
-class Uniform(Initializer):
-    def __init__(self, range=None):
-        self.range = range
-
-    def sample(self, shape):
-        if self.range is None:
-            # no range given, use the Glorot et al. approach.
-            # This code makes some assumptions about the meanings of
-            # the different dimensions, which hold for
-            # layers.DenseLayer and layers.Conv*DLayer, but not
-            # necessarily for other layer types.
-            n1, n2 = shape[:2]
-            receptive_field_size = np.prod(shape[2:])
-            m = np.sqrt(6.0 / ((n1 + n2) * receptive_field_size))
-            range = (-m, m)
-
-        elif isinstance(self.range, Number):
-            range = (-self.range, self.range)
-
-        else:
-            range = self.range
-
-        return floatX(np.random.uniform(
-            low=range[0], high=range[1], size=shape))
 
 
 class Orthogonal(Initializer):

--- a/lasagne/layers/conv.py
+++ b/lasagne/layers/conv.py
@@ -37,8 +37,9 @@ def conv_output_length(input_length, filter_length,
 
 class Conv1DLayer(Layer):
     def __init__(self, incoming, num_filters, filter_length, stride=1,
-                 border_mode="valid", untie_biases=False, W=init.Uniform(),
-                 b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
+                 border_mode="valid", untie_biases=False,
+                 W=init.GlorotUniform(), b=init.Constant(0.),
+                 nonlinearity=nonlinearities.rectify,
                  convolution=conv.conv1d_mc0, **kwargs):
         super(Conv1DLayer, self).__init__(incoming, **kwargs)
         if nonlinearity is None:
@@ -121,8 +122,9 @@ class Conv1DLayer(Layer):
 
 class Conv2DLayer(Layer):
     def __init__(self, incoming, num_filters, filter_size, strides=(1, 1),
-                 border_mode="valid", untie_biases=False, W=init.Uniform(),
-                 b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
+                 border_mode="valid", untie_biases=False,
+                 W=init.GlorotUniform(), b=init.Constant(0.),
+                 nonlinearity=nonlinearities.rectify,
                  convolution=T.nnet.conv2d, **kwargs):
         super(Conv2DLayer, self).__init__(incoming, **kwargs)
         if nonlinearity is None:

--- a/lasagne/layers/corrmm.py
+++ b/lasagne/layers/corrmm.py
@@ -32,7 +32,7 @@ class MMLayer(Layer):
 
 class Conv2DMMLayer(MMLayer):
     def __init__(self, incoming, num_filters, filter_size, strides=(1, 1),
-                 border_mode=None, untie_biases=False, W=init.Uniform(),
+                 border_mode=None, untie_biases=False, W=init.GlorotUniform(),
                  b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
                  pad=None, flip_filters=False, **kwargs):
         super(Conv2DMMLayer, self).__init__(incoming, **kwargs)

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -40,7 +40,7 @@ class CCLayer(Layer):
 
 class Conv2DCCLayer(CCLayer):
     def __init__(self, incoming, num_filters, filter_size, strides=(1, 1),
-                 border_mode=None, untie_biases=False, W=init.Uniform(),
+                 border_mode=None, untie_biases=False, W=None,
                  b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
                  pad=None, dimshuffle=True, flip_filters=False, partial_sum=1,
                  **kwargs):
@@ -92,6 +92,12 @@ class Conv2DCCLayer(CCLayer):
                                    "Conv2DCCLayer: %s" % border_mode)
         else:
             self.pad = pad
+
+        if W is None:
+            if dimshuffle:
+                W = init.GlorotUniform()
+            else:
+                W = init.GlorotUniform_c01b()
 
         self.W = self.create_param(W, self.get_W_shape())
         if b is None:
@@ -301,7 +307,7 @@ class NINLayer_c01b(Layer):
     and reshapes required and might be faster as a result.
     """
     def __init__(self, incoming, num_units, untie_biases=False,
-                 W=init.Uniform(), b=init.Constant(0.),
+                 W=init.GlorotUniform_c01b(), b=init.Constant(0.),
                  nonlinearity=nonlinearities.rectify, **kwargs):
         super(NINLayer_c01b, self).__init__(incoming, **kwargs)
         if nonlinearity is None:

--- a/lasagne/layers/dense.py
+++ b/lasagne/layers/dense.py
@@ -51,7 +51,7 @@ class DenseLayer(Layer):
         >>> l_in = InputLayer((100, 20))
         >>> l1 = DenseLayer(l_in, num_units=50)
     """
-    def __init__(self, incoming, num_units, W=init.Uniform(),
+    def __init__(self, incoming, num_units, W=init.GlorotUniform(),
                  b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
                  **kwargs):
         super(DenseLayer, self).__init__(incoming, **kwargs)
@@ -98,7 +98,7 @@ class NINLayer(Layer):
     so NINLayer can be used to implement 1D, 2D, 3D, ... convolutions.
     """
     def __init__(self, incoming, num_units, untie_biases=False,
-                 W=init.Uniform(), b=init.Constant(0.),
+                 W=init.GlorotUniform(), b=init.Constant(0.),
                  nonlinearity=nonlinearities.rectify, **kwargs):
         super(NINLayer, self).__init__(incoming, **kwargs)
         if nonlinearity is None:

--- a/lasagne/layers/dnn.py
+++ b/lasagne/layers/dnn.py
@@ -48,7 +48,7 @@ class MaxPool2DDNNLayer(Pool2DDNNLayer):  # for consistency
 
 class Conv2DDNNLayer(DNNLayer):
     def __init__(self, incoming, num_filters, filter_size, strides=(1, 1),
-                 border_mode=None, untie_biases=False, W=init.Uniform(),
+                 border_mode=None, untie_biases=False, W=init.GlorotUniform(),
                  b=init.Constant(0.), nonlinearity=nonlinearities.rectify,
                  pad=None, flip_filters=False, **kwargs):
         super(Conv2DDNNLayer, self).__init__(incoming, **kwargs)

--- a/lasagne/tests/test_init.py
+++ b/lasagne/tests/test_init.py
@@ -18,6 +18,31 @@ def test_normal():
     assert 0.009 < sample.std() < 0.011
 
 
+def test_uniform_range_as_number():
+    from lasagne.init import Uniform
+
+    sample = Uniform(1.0).sample((300, 400))
+    assert sample.shape == (300, 400)
+    assert -1.1 < sample.min() < -0.9
+    assert 0.9 < sample.max() < 1.1
+
+
+def test_uniform_range_as_range():
+    from lasagne.init import Uniform
+
+    sample = Uniform((0.0, 1.0)).sample((300, 400))
+    assert sample.shape == (300, 400)
+    assert -0.1 < sample.min() < 0.1
+    assert 0.9 < sample.max() < 1.1
+
+
+def test_uniform_mean_std():
+    from lasagne.init import Uniform
+    sample = Uniform(std=1.0, mean=5.0).sample((300, 400))
+    assert 4.9 < sample.mean() < 5.1
+    assert 0.9 < sample.std() < 1.1
+
+
 def test_glorot_normal():
     from lasagne.init import GlorotNormal
 
@@ -61,24 +86,6 @@ def test_glorot_normal_c01b_4d_only():
 
     with pytest.raises(RuntimeError):
         GlorotNormal_c01b().sample((100, 100, 100))
-
-
-def test_uniform_range_as_number():
-    from lasagne.init import Uniform
-
-    sample = Uniform(1.0).sample((300, 400))
-    assert sample.shape == (300, 400)
-    assert -1.1 < sample.min() < -0.9
-    assert 0.9 < sample.max() < 1.1
-
-
-def test_uniform_range_as_range():
-    from lasagne.init import Uniform
-
-    sample = Uniform((0.0, 1.0)).sample((300, 400))
-    assert sample.shape == (300, 400)
-    assert -0.1 < sample.min() < 0.1
-    assert 0.9 < sample.max() < 1.1
 
 
 def test_glorot_uniform():

--- a/lasagne/tests/test_init.py
+++ b/lasagne/tests/test_init.py
@@ -15,37 +15,52 @@ def test_normal():
 
     sample = Normal().sample((100, 200))
     assert -0.001 < sample.mean() < 0.001
+    assert 0.009 < sample.std() < 0.011
 
 
-def test_constant():
-    from lasagne.init import Constant
+def test_glorot_normal():
+    from lasagne.init import GlorotNormal
 
-    sample = Constant(1.0).sample((10, 20))
-    assert (sample == 1.0).all()
-
-
-def test_sparse():
-    from lasagne.init import Sparse
-
-    sample = Sparse(sparsity=0.5).sample((10, 20))
-    assert (sample == 0.0).sum() == (sample != 0.0).sum()
-    assert (sample == 0.0).sum() == (10 * 20) / 2
+    sample = GlorotNormal().sample((100, 100))
+    assert -0.01 < sample.mean() < 0.01
+    assert 0.09 < sample.std() < 0.11
 
 
-def test_uniform_glorot():
-    from lasagne.init import Uniform
+def test_glorot_normal_receptive_field():
+    from lasagne.init import GlorotNormal
 
-    sample = Uniform().sample((150, 450))
-    assert -0.11 < sample.min() < -0.09
-    assert 0.09 < sample.max() < 0.11
+    sample = GlorotNormal().sample((50, 50, 2))
+    assert -0.01 < sample.mean() < 0.01
+    assert 0.09 < sample.std() < 0.11
 
 
-def test_uniform_glorot_receptive_field():
-    from lasagne.init import Uniform
+def test_glorot_normal_gain():
+    from lasagne.init import GlorotNormal
 
-    sample = Uniform().sample((150, 150, 2))
-    assert -0.11 < sample.min() < -0.09
-    assert 0.09 < sample.max() < 0.11
+    sample = GlorotNormal(gain=10.0).sample((100, 100))
+    assert -0.1 < sample.mean() < 0.1
+    assert 0.9 < sample.std() < 1.1
+
+
+def test_glorot_normal_c01b():
+    from lasagne.init import GlorotNormal_c01b
+
+    sample = GlorotNormal_c01b().sample((25, 2, 2, 25))
+    assert -0.01 < sample.mean() < 0.01
+    assert 0.09 < sample.std() < 0.11
+
+
+def test_glorot_normal_c01b_4d_only():
+    from lasagne.init import GlorotNormal_c01b
+
+    with pytest.raises(RuntimeError):
+        GlorotNormal_c01b().sample((100,))
+
+    with pytest.raises(RuntimeError):
+        GlorotNormal_c01b().sample((100, 100))
+
+    with pytest.raises(RuntimeError):
+        GlorotNormal_c01b().sample((100, 100, 100))
 
 
 def test_uniform_range_as_number():
@@ -64,6 +79,66 @@ def test_uniform_range_as_range():
     assert sample.shape == (300, 400)
     assert -0.1 < sample.min() < 0.1
     assert 0.9 < sample.max() < 1.1
+
+
+def test_glorot_uniform():
+    from lasagne.init import GlorotUniform
+
+    sample = GlorotUniform().sample((150, 450))
+    assert -0.11 < sample.min() < -0.09
+    assert 0.09 < sample.max() < 0.11
+
+
+def test_glorot_uniform_receptive_field():
+    from lasagne.init import GlorotUniform
+
+    sample = GlorotUniform().sample((150, 150, 2))
+    assert -0.11 < sample.min() < -0.09
+    assert 0.09 < sample.max() < 0.11
+
+
+def test_glorot_uniform_gain():
+    from lasagne.init import GlorotUniform
+
+    sample = GlorotUniform(gain=10.0).sample((150, 450))
+    assert -1.1 < sample.min() < -0.9
+    assert 0.9 < sample.max() < 1.1
+
+
+def test_glorot_uniform_c01b():
+    from lasagne.init import GlorotUniform_c01b
+
+    sample = GlorotUniform_c01b().sample((75, 2, 2, 75))
+    assert -0.11 < sample.min() < -0.09
+    assert 0.09 < sample.max() < 0.11
+
+
+def test_glorot_uniform_c01b_4d_only():
+    from lasagne.init import GlorotUniform_c01b
+
+    with pytest.raises(RuntimeError):
+        GlorotUniform_c01b().sample((100,))
+
+    with pytest.raises(RuntimeError):
+        GlorotUniform_c01b().sample((100, 100))
+
+    with pytest.raises(RuntimeError):
+        GlorotUniform_c01b().sample((100, 100, 100))
+
+
+def test_constant():
+    from lasagne.init import Constant
+
+    sample = Constant(1.0).sample((10, 20))
+    assert (sample == 1.0).all()
+
+
+def test_sparse():
+    from lasagne.init import Sparse
+
+    sample = Sparse(sparsity=0.5).sample((10, 20))
+    assert (sample == 0.0).sum() == (sample != 0.0).sum()
+    assert (sample == 0.0).sum() == (10 * 20) / 2
 
 
 def test_orthogonal():

--- a/lasagne/tests/test_init.py
+++ b/lasagne/tests/test_init.py
@@ -23,8 +23,8 @@ def test_uniform_range_as_number():
 
     sample = Uniform(1.0).sample((300, 400))
     assert sample.shape == (300, 400)
-    assert -1.1 < sample.min() < -0.9
-    assert 0.9 < sample.max() < 1.1
+    assert -1.0 <= sample.min() < -0.9
+    assert 0.9 < sample.max() <= 1.0
 
 
 def test_uniform_range_as_range():
@@ -32,8 +32,8 @@ def test_uniform_range_as_range():
 
     sample = Uniform((0.0, 1.0)).sample((300, 400))
     assert sample.shape == (300, 400)
-    assert -0.1 < sample.min() < 0.1
-    assert 0.9 < sample.max() < 1.1
+    assert 0.0 <= sample.min() < 0.1
+    assert 0.9 < sample.max() <= 1.0
 
 
 def test_uniform_mean_std():
@@ -92,32 +92,32 @@ def test_glorot_uniform():
     from lasagne.init import GlorotUniform
 
     sample = GlorotUniform().sample((150, 450))
-    assert -0.11 < sample.min() < -0.09
-    assert 0.09 < sample.max() < 0.11
+    assert -0.1 <= sample.min() < -0.09
+    assert 0.09 < sample.max() <= 0.1
 
 
 def test_glorot_uniform_receptive_field():
     from lasagne.init import GlorotUniform
 
     sample = GlorotUniform().sample((150, 150, 2))
-    assert -0.11 < sample.min() < -0.09
-    assert 0.09 < sample.max() < 0.11
+    assert -0.10 <= sample.min() < -0.09
+    assert 0.09 < sample.max() <= 0.10
 
 
 def test_glorot_uniform_gain():
     from lasagne.init import GlorotUniform
 
     sample = GlorotUniform(gain=10.0).sample((150, 450))
-    assert -1.1 < sample.min() < -0.9
-    assert 0.9 < sample.max() < 1.1
+    assert -1.0 <= sample.min() < -0.9
+    assert 0.9 < sample.max() <= 1.0
 
 
 def test_glorot_uniform_c01b():
     from lasagne.init import GlorotUniform_c01b
 
     sample = GlorotUniform_c01b().sample((75, 2, 2, 75))
-    assert -0.11 < sample.min() < -0.09
-    assert 0.09 < sample.max() < 0.11
+    assert -0.1 <= sample.min() < -0.09
+    assert 0.09 < sample.max() <= 0.1
 
 
 def test_glorot_uniform_c01b_4d_only():
@@ -143,9 +143,8 @@ def test_constant():
 def test_sparse():
     from lasagne.init import Sparse
 
-    sample = Sparse(sparsity=0.5).sample((10, 20))
-    assert (sample == 0.0).sum() == (sample != 0.0).sum()
-    assert (sample == 0.0).sum() == (10 * 20) / 2
+    sample = Sparse(sparsity=0.1).sample((10, 20))
+    assert (sample != 0.0).sum() == (10 * 20) * 0.1
 
 
 def test_orthogonal():


### PR DESCRIPTION
This PR cleans up the `lasagne.init` module. It introduces separate classes for "Glorot-style" initialization, `GlorotUniform` and `GlorotNormal`.

This means `Uniform` no longer does Glorot-style init by default. Instead, it will use a default range of (-0.01, 0.01). I've added a warning to alert people of this, in case they're using `Uniform` in this way. Their training runs might suddenly take a lot longer to converge!

Accordingly, I've also changed the default initialization to `GlorotUniform` everywhere in the library.

I've added separate `GlorotUniform_c01b` and `GlorotNormal_c01b` initializers for the c01b case (useful for cuda-convnet-based layers). We discussed a fancier approach using `fan_in` and `fan_out` parameters in #49, but for now I don't think this will be worth it. Having separate classes for the `c01b` case seemed like a simpler approach, although it does lead to a little bit of code duplication.

This PR also addresses the bug reported in #49: the default initializer for `W` in `lasagne.layers.cuda_convnet.Conv2DCCLayer` is now `GlorotUniform` or `GlorotUniform_c01b`, depending on whether `dimshuffle` is `True` or `False`.

In the `mnist_conv_cc.py` example, I've removed all explicit specifications of initializers for `W`, because this should now depend on whether `dimshuffle` is `True` or `False`. I believe they were only specified explicitly because the default was broken to begin with.

This also addresses #87: the Glorot-style initializers have a `gain` parameter, like `Orthogonal` already had before.

Glorot-style initialization means that the standard deviation of the initialization distribution is proportional to `2/(fan_in + fan_out)`. Some people prefer to use `1/fan_in` instead, but this PR does not address that. Does anyone think this is worth adding as well? I think this was basically the idea of PR #165.

Feedback is welcome!