### PR TITLE
add MaxPool1DLayer + tests

### DIFF
--- a/lasagne/layers/pool.py
+++ b/lasagne/layers/pool.py
@@ -7,6 +7,7 @@ from theano.tensor.signal import downsample
 
 
 __all__ = [
+    "MaxPool1DLayer",
     "MaxPool2DLayer",
     "FeaturePoolLayer",
     "FeatureWTALayer",
@@ -46,6 +47,28 @@ def pool_output_length(input_length, pool_length, ignore_border=True):
     return int(np.ceil(float(input_length) / pool_length))
 
 
+class MaxPool1DLayer(Layer):
+    def __init__(self, incoming, ds, ignore_border=False, **kwargs):
+        super(MaxPool1DLayer, self).__init__(incoming, **kwargs)
+        self.ds = ds  # an integer
+        self.ignore_border = ignore_border
+
+    def get_output_shape_for(self, input_shape):
+        output_shape = list(input_shape)  # copy / convert to mutable list
+
+        output_shape[2] = pool_output_length(input_shape[2],
+                                             self.ds,
+                                             ignore_border=self.ignore_border)
+
+        return tuple(output_shape)
+
+    def get_output_for(self, input, **kwargs):
+        input_4d = T.shape_padright(input, 1)
+        pooled = downsample.max_pool_2d(input_4d, (self.ds, 1),
+                                        self.ignore_border)
+        return pooled[:, :, :, 0]
+
+
 class MaxPool2DLayer(Layer):
     def __init__(self, incoming, ds, ignore_border=False, **kwargs):
         super(MaxPool2DLayer, self).__init__(incoming, **kwargs)
@@ -69,8 +92,7 @@ class MaxPool2DLayer(Layer):
         return downsample.max_pool_2d(input, self.ds, self.ignore_border)
 
 
-# TODO: add reshape-based implementation to MaxPool2DLayer
-# TODO: add MaxPool1DLayer
+# TODO: add reshape-based implementation to MaxPool*DLayer
 # TODO: add MaxPool3DLayer
 
 

--- a/lasagne/tests/layers/test_pool.py
+++ b/lasagne/tests/layers/test_pool.py
@@ -4,6 +4,24 @@ import pytest
 import theano
 
 
+def max_pool_1d(data, ds):
+    data_truncated = data[:, :, :(data.shape[2] // ds) * ds]
+    data_pooled = data_truncated.reshape((-1, ds)).max(axis=1)
+    return data_pooled.reshape(data.shape[:2] + (data.shape[2] // ds,))
+
+
+def max_pool_2d(data, ds):
+    data_truncated = data[:, :, :(data.shape[2] // ds[0]) * ds[0],
+                          :(data.shape[3] // ds[1]) * ds[1]]
+    data_reshaped = data_truncated.reshape((-1, data.shape[2] // ds[0], ds[0],
+                                            data.shape[3] // ds[1], ds[1]))
+
+    data_pooled = data_reshaped.max(axis=4).max(axis=2)
+
+    return data_pooled.reshape(data.shape[:2] + (data.shape[2] // ds[0],
+                                                 data.shape[3] // ds[1]))
+
+
 class TestMaxPool1DLayer:
     @pytest.fixture(params=[(32, 64, 128), (None, 64, 128)])
     def input_layer(self, request):
@@ -14,7 +32,19 @@ class TestMaxPool1DLayer:
         from lasagne.layers.pool import MaxPool1DLayer
         return MaxPool1DLayer(input_layer, ds=2)
 
-    def test_get_output_for(self, layer):
+    @pytest.fixture
+    def layer_ignoreborder(self, input_layer):
+        from lasagne.layers.pool import MaxPool1DLayer
+        return MaxPool1DLayer(input_layer, ds=2, ignore_border=True)
+
+    def test_get_output_for(self, layer_ignoreborder):
+        input = numpy.random.randn(32, 64, 128)
+        input_theano = theano.shared(input)
+        result = layer_ignoreborder.get_output_for(input_theano)
+        result_eval = result.eval()
+        assert numpy.all(result_eval == max_pool_1d(input, 2))
+
+    def test_get_output_for_shape(self, layer):
         input = theano.shared(numpy.ones((32, 64, 128)))
         result = layer.get_output_for(input)
         result_eval = result.eval()
@@ -35,7 +65,19 @@ class TestMaxPool2DLayer:
         from lasagne.layers.pool import MaxPool2DLayer
         return MaxPool2DLayer(input_layer, ds=(2, 2))
 
-    def test_get_output_for(self, layer):
+    @pytest.fixture
+    def layer_ignoreborder(self, input_layer):
+        from lasagne.layers.pool import MaxPool2DLayer
+        return MaxPool2DLayer(input_layer, ds=(2, 2), ignore_border=True)
+
+    def test_get_output_for(self, layer_ignoreborder):
+        input = numpy.random.randn(32, 64, 24, 24)
+        input_theano = theano.shared(input)
+        result = layer_ignoreborder.get_output_for(input_theano)
+        result_eval = result.eval()
+        assert numpy.all(result_eval == max_pool_2d(input, (2, 2)))
+
+    def test_get_output_for_shape(self, layer):
         input = theano.shared(numpy.ones((32, 64, 24, 24)))
         result = layer.get_output_for(input)
         result_eval = result.eval()

--- a/lasagne/tests/layers/test_pool.py
+++ b/lasagne/tests/layers/test_pool.py
@@ -1,0 +1,48 @@
+from mock import Mock
+import numpy
+import pytest
+import theano
+
+
+class TestMaxPool1DLayer:
+    @pytest.fixture(params=[(32, 64, 128), (None, 64, 128)])
+    def input_layer(self, request):
+        return Mock(get_output_shape=lambda: request.param)
+
+    @pytest.fixture
+    def layer(self, input_layer):
+        from lasagne.layers.pool import MaxPool1DLayer
+        return MaxPool1DLayer(input_layer, ds=2)
+
+    def test_get_output_for(self, layer):
+        input = theano.shared(numpy.ones((32, 64, 128)))
+        result = layer.get_output_for(input)
+        result_eval = result.eval()
+        assert result_eval.shape == (32, 64, 64)
+
+    def test_get_output_shape_for(self, layer):
+        assert layer.get_output_shape_for((None, 64, 128)) == (None, 64, 64)
+        assert layer.get_output_shape_for((32, 64, 128)) == (32, 64, 64)
+
+
+class TestMaxPool2DLayer:
+    @pytest.fixture(params=[(32, 64, 24, 24), (None, 64, 24, 24)])
+    def input_layer(self, request):
+        return Mock(get_output_shape=lambda: request.param)
+
+    @pytest.fixture
+    def layer(self, input_layer):
+        from lasagne.layers.pool import MaxPool2DLayer
+        return MaxPool2DLayer(input_layer, ds=(2, 2))
+
+    def test_get_output_for(self, layer):
+        input = theano.shared(numpy.ones((32, 64, 24, 24)))
+        result = layer.get_output_for(input)
+        result_eval = result.eval()
+        assert result_eval.shape == (32, 64, 12, 12)
+
+    def test_get_output_shape_for(self, layer):
+        assert (layer.get_output_shape_for((None, 64, 24, 24)) ==
+                (None, 64, 12, 12))
+        assert (layer.get_output_shape_for((32, 64, 24, 24)) ==
+                (32, 64, 12, 12))


### PR DESCRIPTION
This adds a `MaxPool1DLayer` that just uses `max_pool_2d` with an extra dimension of size 1. It also adds rudimentary tests for `MaxPool1DLayer` and `MaxPool2DLayer`.