### PR TITLE
He-style initializers

### DIFF
--- a/lasagne/init.py
+++ b/lasagne/init.py
@@ -62,7 +62,7 @@ class Glorot(Initializer):
         if self.c01b:
             if len(shape) != 4:
                 raise RuntimeError(
-                    "If c01b is True, only shapes of lenght 4 are accepted")
+                    "If c01b is True, only shapes of length 4 are accepted")
 
             n1, n2 = shape[0], shape[3]
             receptive_field_size = shape[1] * shape[2]
@@ -97,7 +97,7 @@ class He(Initializer):
         if self.c01b:
             if len(shape) != 4:
                 raise RuntimeError(
-                    "If c01b is True, only shapes of lenght 4 are accepted")
+                    "If c01b is True, only shapes of length 4 are accepted")
 
             fan_in = np.prod(shape[:3])
         else:

--- a/lasagne/init.py
+++ b/lasagne/init.py
@@ -50,101 +50,77 @@ class Uniform(Initializer):
 
 
 class Glorot(Initializer):
-    def __init__(self, initializer=Normal, gain=1.0):
+    def __init__(self, initializer=Normal, gain=1.0, c01b=False):
         if gain == 'relu':
             gain = np.sqrt(2)
 
         self.initializer = initializer
         self.gain = gain
+        self.c01b = c01b
 
     def sample(self, shape):
-        n1, n2 = shape[:2]
-        receptive_field_size = np.prod(shape[2:])
+        if self.c01b:
+            if len(shape) != 4:
+                raise RuntimeError(
+                    "If c01b is True, only shapes of lenght 4 are accepted")
+
+            n1, n2 = shape[0], shape[3]
+            receptive_field_size = shape[1] * shape[2]
+        else:
+            n1, n2 = shape[:2]
+            receptive_field_size = np.prod(shape[2:])
+
         std = self.gain * np.sqrt(2.0 / ((n1 + n2) * receptive_field_size))
         return self.initializer(std=std).sample(shape)
 
 
 class GlorotNormal(Glorot):
-    def __init__(self, gain=1.0):
-        super(GlorotNormal, self).__init__(Normal, gain)
+    def __init__(self, gain=1.0, c01b=False):
+        super(GlorotNormal, self).__init__(Normal, gain, c01b)
 
 
 class GlorotUniform(Glorot):
-    def __init__(self, gain=1.0):
-        super(GlorotUniform, self).__init__(Uniform, gain)
-
-
-class Glorot_c01b(Glorot):
-    def sample(self, shape):
-        if len(shape) != 4:
-            raise RuntimeError(
-                "This initializer only works with shapes of length 4")
-
-        n1, n2 = shape[0], shape[3]
-        receptive_field_size = shape[1] * shape[2]
-        std = self.gain * np.sqrt(2.0 / ((n1 + n2) * receptive_field_size))
-        return self.initializer(std=std).sample(shape)
-
-
-class GlorotNormal_c01b(Glorot_c01b):
-    def __init__(self, gain=1.0):
-        super(GlorotNormal_c01b, self).__init__(Normal, gain)
-
-
-class GlorotUniform_c01b(Glorot_c01b):
-    def __init__(self, gain=1.0):
-        super(GlorotUniform_c01b, self).__init__(Uniform, gain)
+    def __init__(self, gain=1.0, c01b=False):
+        super(GlorotUniform, self).__init__(Uniform, gain, c01b)
 
 
 class He(Initializer):
-    def __init__(self, initializer=Normal, gain=1.0):
+    def __init__(self, initializer=Normal, gain=1.0, c01b=False):
         if gain == 'relu':
             gain = np.sqrt(2)
 
         self.initializer = initializer
         self.gain = gain
+        self.c01b = c01b
 
     def sample(self, shape):
-        if len(shape) == 2:
-            fan_in = shape[0]
-        elif len(shape) > 2:
-            fan_in = np.prod(shape[1:])
+        if self.c01b:
+            if len(shape) != 4:
+                raise RuntimeError(
+                    "If c01b is True, only shapes of lenght 4 are accepted")
+
+            fan_in = np.prod(shape[:3])
         else:
-            raise RuntimeError(
-                "This initializer only works with shapes of length >= 2")
+            if len(shape) == 2:
+                fan_in = shape[0]
+            elif len(shape) > 2:
+                fan_in = np.prod(shape[1:])
+            else:
+                raise RuntimeError(
+                    "This initializer only works with shapes of length >= 2")
+
         std = self.gain * np.sqrt(1.0 / fan_in)
         return self.initializer(std=std).sample(shape)
 
 
 class HeNormal(He):
-    def __init__(self, gain=1.0):
-        super(HeNormal, self).__init__(Normal, gain)
+    def __init__(self, gain=1.0, c01b=False):
+        super(HeNormal, self).__init__(Normal, gain, c01b)
 
 
 class HeUniform(He):
-    def __init__(self, gain=1.0):
-        super(HeUniform, self).__init__(Uniform, gain)
-
-
-class He_c01b(He):
-    def sample(self, shape):
-        if len(shape) != 4:
-            raise RuntimeError(
-                "This initializer only works with shapes of length 4")
-
-        fan_in = np.prod(shape[:3])
-        std = self.gain * np.sqrt(1.0 / fan_in)
-        return self.initializer(std=std).sample(shape)
-
-
-class HeNormal_c01b(He_c01b):
-    def __init__(self, gain=1.0):
-        super(HeNormal_c01b, self).__init__(Normal, gain)
-
-
-class HeUniform_c01b(He_c01b):
-    def __init__(self, gain=1.0):
-        super(HeUniform_c01b, self).__init__(Uniform, gain)
+    def __init__(self, gain=1.0, c01b=False):
+        super(HeUniform, self).__init__(Uniform, gain, c01b)
 
 
 class Constant(Initializer):

--- a/lasagne/init.py
+++ b/lasagne/init.py
@@ -96,6 +96,57 @@ class GlorotUniform_c01b(Glorot_c01b):
         super(GlorotUniform_c01b, self).__init__(Uniform, gain)
 
 
+class He(Initializer):
+    def __init__(self, initializer=Normal, gain=1.0):
+        if gain == 'relu':
+            gain = np.sqrt(2)
+
+        self.initializer = initializer
+        self.gain = gain
+
+    def sample(self, shape):
+        if len(shape) == 2:
+            fan_in = shape[0]
+        elif len(shape) > 2:
+            fan_in = np.prod(shape[1:])
+        else:
+            raise RuntimeError(
+                "This initializer only works with shapes of length >= 2")
+        std = self.gain * np.sqrt(1.0 / fan_in)
+        return self.initializer(std=std).sample(shape)
+
+
+class HeNormal(He):
+    def __init__(self, gain=1.0):
+        super(HeNormal, self).__init__(Normal, gain)
+
+
+class HeUniform(He):
+    def __init__(self, gain=1.0):
+        super(HeUniform, self).__init__(Uniform, gain)
+
+
+class He_c01b(He):
+    def sample(self, shape):
+        if len(shape) != 4:
+            raise RuntimeError(
+                "This initializer only works with shapes of length 4")
+
+        fan_in = np.prod(shape[:3])
+        std = self.gain * np.sqrt(1.0 / fan_in)
+        return self.initializer(std=std).sample(shape)
+
+
+class HeNormal_c01b(He_c01b):
+    def __init__(self, gain=1.0):
+        super(HeNormal_c01b, self).__init__(Normal, gain)
+
+
+class HeUniform_c01b(He_c01b):
+    def __init__(self, gain=1.0):
+        super(HeUniform_c01b, self).__init__(Uniform, gain)
+
+
 class Constant(Initializer):
     def __init__(self, val=0.0):
         self.val = val

--- a/lasagne/layers/cuda_convnet.py
+++ b/lasagne/layers/cuda_convnet.py
@@ -97,7 +97,7 @@ class Conv2DCCLayer(CCLayer):
             if dimshuffle:
                 W = init.GlorotUniform()
             else:
-                W = init.GlorotUniform_c01b()
+                W = init.GlorotUniform(c01b=True)
 
         self.W = self.create_param(W, self.get_W_shape())
         if b is None:
@@ -307,7 +307,7 @@ class NINLayer_c01b(Layer):
     and reshapes required and might be faster as a result.
     """
     def __init__(self, incoming, num_units, untie_biases=False,
-                 W=init.GlorotUniform_c01b(), b=init.Constant(0.),
+                 W=init.GlorotUniform(c01b=True), b=init.Constant(0.),
                  nonlinearity=nonlinearities.rectify, **kwargs):
         super(NINLayer_c01b, self).__init__(incoming, **kwargs)
         if nonlinearity is None:

--- a/lasagne/tests/test_init.py
+++ b/lasagne/tests/test_init.py
@@ -68,24 +68,24 @@ def test_glorot_normal_gain():
 
 
 def test_glorot_normal_c01b():
-    from lasagne.init import GlorotNormal_c01b
+    from lasagne.init import GlorotNormal
 
-    sample = GlorotNormal_c01b().sample((25, 2, 2, 25))
+    sample = GlorotNormal(c01b=True).sample((25, 2, 2, 25))
     assert -0.01 < sample.mean() < 0.01
     assert 0.09 < sample.std() < 0.11
 
 
 def test_glorot_normal_c01b_4d_only():
-    from lasagne.init import GlorotNormal_c01b
+    from lasagne.init import GlorotNormal
 
     with pytest.raises(RuntimeError):
-        GlorotNormal_c01b().sample((100,))
+        GlorotNormal(c01b=True).sample((100,))
 
     with pytest.raises(RuntimeError):
-        GlorotNormal_c01b().sample((100, 100))
+        GlorotNormal(c01b=True).sample((100, 100))
 
     with pytest.raises(RuntimeError):
-        GlorotNormal_c01b().sample((100, 100, 100))
+        GlorotNormal(c01b=True).sample((100, 100, 100))
 
 
 def test_glorot_uniform():
@@ -113,24 +113,24 @@ def test_glorot_uniform_gain():
 
 
 def test_glorot_uniform_c01b():
-    from lasagne.init import GlorotUniform_c01b
+    from lasagne.init import GlorotUniform
 
-    sample = GlorotUniform_c01b().sample((75, 2, 2, 75))
+    sample = GlorotUniform(c01b=True).sample((75, 2, 2, 75))
     assert -0.1 <= sample.min() < -0.09
     assert 0.09 < sample.max() <= 0.1
 
 
 def test_glorot_uniform_c01b_4d_only():
-    from lasagne.init import GlorotUniform_c01b
+    from lasagne.init import GlorotUniform
 
     with pytest.raises(RuntimeError):
-        GlorotUniform_c01b().sample((100,))
+        GlorotUniform(c01b=True).sample((100,))
 
     with pytest.raises(RuntimeError):
-        GlorotUniform_c01b().sample((100, 100))
+        GlorotUniform(c01b=True).sample((100, 100))
 
     with pytest.raises(RuntimeError):
-        GlorotUniform_c01b().sample((100, 100, 100))
+        GlorotUniform(c01b=True).sample((100, 100, 100))
 
 
 def test_he_normal():
@@ -158,24 +158,24 @@ def test_he_normal_gain():
 
 
 def test_he_normal_c01b():
-    from lasagne.init import HeNormal_c01b
+    from lasagne.init import HeNormal
 
-    sample = HeNormal_c01b().sample((25, 2, 2, 25))
+    sample = HeNormal(c01b=True).sample((25, 2, 2, 25))
     assert -0.01 < sample.mean() < 0.01
     assert 0.09 < sample.std() < 0.11
 
 
 def test_he_normal_c01b_4d_only():
-    from lasagne.init import HeNormal_c01b
+    from lasagne.init import HeNormal
 
     with pytest.raises(RuntimeError):
-        HeNormal_c01b().sample((100,))
+        HeNormal(c01b=True).sample((100,))
 
     with pytest.raises(RuntimeError):
-        HeNormal_c01b().sample((100, 100))
+        HeNormal(c01b=True).sample((100, 100))
 
     with pytest.raises(RuntimeError):
-        HeNormal_c01b().sample((100, 100, 100))
+        HeNormal(c01b=True).sample((100, 100, 100))
 
 
 def test_he_uniform():
@@ -203,24 +203,24 @@ def test_he_uniform_gain():
 
 
 def test_he_uniform_c01b():
-    from lasagne.init import HeUniform_c01b
+    from lasagne.init import HeUniform
 
-    sample = HeUniform_c01b().sample((75, 2, 2, 75))
+    sample = HeUniform(c01b=True).sample((75, 2, 2, 75))
     assert -0.1 <= sample.min() < -0.09
     assert 0.09 < sample.max() <= 0.1
 
 
 def test_he_uniform_c01b_4d_only():
-    from lasagne.init import HeUniform_c01b
+    from lasagne.init import HeUniform
 
     with pytest.raises(RuntimeError):
-        HeUniform_c01b().sample((100,))
+        HeUniform(c01b=True).sample((100,))
 
     with pytest.raises(RuntimeError):
-        HeUniform_c01b().sample((100, 100))
+        HeUniform(c01b=True).sample((100, 100))
 
     with pytest.raises(RuntimeError):
-        HeUniform_c01b().sample((100, 100, 100))
+        HeUniform(c01b=True).sample((100, 100, 100))
 
 
 def test_constant():

--- a/lasagne/tests/test_init.py
+++ b/lasagne/tests/test_init.py
@@ -133,6 +133,96 @@ def test_glorot_uniform_c01b_4d_only():
         GlorotUniform_c01b().sample((100, 100, 100))
 
 
+def test_he_normal():
+    from lasagne.init import HeNormal
+
+    sample = HeNormal().sample((100, 100))
+    assert -0.01 < sample.mean() < 0.01
+    assert 0.09 < sample.std() < 0.11
+
+
+def test_he_normal_receptive_field():
+    from lasagne.init import HeNormal
+
+    sample = HeNormal().sample((50, 50, 2))
+    assert -0.01 < sample.mean() < 0.01
+    assert 0.09 < sample.std() < 0.11
+
+
+def test_he_normal_gain():
+    from lasagne.init import HeNormal
+
+    sample = HeNormal(gain=10.0).sample((100, 100))
+    assert -0.1 < sample.mean() < 0.1
+    assert 0.9 < sample.std() < 1.1
+
+
+def test_he_normal_c01b():
+    from lasagne.init import HeNormal_c01b
+
+    sample = HeNormal_c01b().sample((25, 2, 2, 25))
+    assert -0.01 < sample.mean() < 0.01
+    assert 0.09 < sample.std() < 0.11
+
+
+def test_he_normal_c01b_4d_only():
+    from lasagne.init import HeNormal_c01b
+
+    with pytest.raises(RuntimeError):
+        HeNormal_c01b().sample((100,))
+
+    with pytest.raises(RuntimeError):
+        HeNormal_c01b().sample((100, 100))
+
+    with pytest.raises(RuntimeError):
+        HeNormal_c01b().sample((100, 100, 100))
+
+
+def test_he_uniform():
+    from lasagne.init import HeUniform
+
+    sample = HeUniform().sample((300, 200))
+    assert -0.1 <= sample.min() < -0.09
+    assert 0.09 < sample.max() <= 0.1
+
+
+def test_he_uniform_receptive_field():
+    from lasagne.init import HeUniform
+
+    sample = HeUniform().sample((150, 150, 2))
+    assert -0.10 <= sample.min() < -0.09
+    assert 0.09 < sample.max() <= 0.10
+
+
+def test_he_uniform_gain():
+    from lasagne.init import HeUniform
+
+    sample = HeUniform(gain=10.0).sample((300, 200))
+    assert -1.0 <= sample.min() < -0.9
+    assert 0.9 < sample.max() <= 1.0
+
+
+def test_he_uniform_c01b():
+    from lasagne.init import HeUniform_c01b
+
+    sample = HeUniform_c01b().sample((75, 2, 2, 75))
+    assert -0.1 <= sample.min() < -0.09
+    assert 0.09 < sample.max() <= 0.1
+
+
+def test_he_uniform_c01b_4d_only():
+    from lasagne.init import HeUniform_c01b
+
+    with pytest.raises(RuntimeError):
+        HeUniform_c01b().sample((100,))
+
+    with pytest.raises(RuntimeError):
+        HeUniform_c01b().sample((100, 100))
+
+    with pytest.raises(RuntimeError):
+        HeUniform_c01b().sample((100, 100, 100))
+
+
 def test_constant():
     from lasagne.init import Constant
 


### PR DESCRIPTION
I figured I might as well go ahead and add them.

This should supersede #165: `lasagne.init.HeNormal('relu')` should be equivalent to `lasagne.init.ReluNormal()` introduced in that PR.

For some reason I botched my pep8/flake8/pytest install on this PC, so I'm counting on Travis here :)