### PR TITLE
Modular momentum updates plus docstrings

### DIFF
--- a/lasagne/updates.py
+++ b/lasagne/updates.py
@@ -2,78 +2,286 @@
 Functions to generate Theano update dictionaries for training.
 """
 
+from collections import OrderedDict
+
 import numpy as np
 
 import theano
 import theano.tensor as T
 
 
-def sgd(loss, all_params, learning_rate):
-    all_grads = theano.grad(loss, all_params)
-    updates = []
+__all__ = [
+    "sgd",
+    "apply_momentum",
+    "momentum",
+    "apply_nesterov_momentum",
+    "nesterov_momentum",
+    "adagrad",
+    "rmsprop",
+    "adadelta",
+    "norm_constraint",
+]
 
-    for param_i, grad_i in zip(all_params, all_grads):
-        updates.append((param_i, param_i - learning_rate * grad_i))
+
+def get_or_compute_grads(loss_or_grads, params):
+    """Helper function returning a list of gradients.
+
+    Parameters
+    ----------
+    loss_or_grads : symbolic expression or list of expressions
+        A scalar loss expression, or a list of gradient expressions
+    params : list of shared variables
+        The variables to return the gradients for
+
+    Returns
+    -------
+    list of expressions
+        If `loss_or_grads` is a list, it is assumed to be a list of
+        gradients and returned as is, unless it does not match the length
+        of `params`, in which case a `ValueError` is raised.
+        Otherwise, `loss_or_grads` is assumed to be a cost expression and
+        the function returns `theano.grad(loss_or_grads, params)`.
+    """
+    if isinstance(loss_or_grads, list):
+        if not len(loss_or_grads) == len(params):
+            raise ValueError("Got %d gradient expressions for %d parameters" %
+                             (len(loss_or_grads), len(params)))
+        return loss_or_grads
+    else:
+        return theano.grad(loss_or_grads, params)
+
+
+def sgd(loss_or_grads, params, learning_rate):
+    """Stochastic Gradient Descent (SGD) updates.
+
+    Generates update expressions of the form:
+    * ``param := param - learning_rate * gradient``
+
+    Parameters
+    ----------
+    loss_or_grads : symbolic expression or list of expressions
+        A scalar loss expression, or a list of gradient expressions
+    params : list of shared variables
+        The variables to generate update expressions for
+    learning_rate : float or symbolic scalar
+        The learning rate controlling the size of update steps
+
+    Returns
+    -------
+    OrderedDict
+        A dictionary mapping each parameter to its update expression
+    """
+    grads = get_or_compute_grads(loss_or_grads, params)
+    updates = OrderedDict()
+
+    for param, grad in zip(params, grads):
+        updates[param] = param - learning_rate * grad
 
     return updates
 
 
-def momentum(loss, all_params, learning_rate, momentum=0.9):
-    all_grads = theano.grad(loss, all_params)
-    updates = []
+def apply_momentum(updates, params=None, momentum=0.9):
+    """Returns a modified update dictionary that includes momentum terms.
 
-    for param_i, grad_i in zip(all_params, all_grads):
-        mparam_i = theano.shared(np.zeros(param_i.get_value().shape,
-                                          dtype=theano.config.floatX),
-                                 broadcastable=param_i.broadcastable)
-        v = momentum * mparam_i - learning_rate * grad_i
-        updates.append((mparam_i, v))
-        updates.append((param_i, param_i + v))
+    Generates update expressions of the form:
+    * ``velocity := momentum * velocity + updates[param] - param``
+    * ``param := param + velocity``
+
+    Parameters
+    ----------
+    updates : OrderedDict
+        A dictionary mapping parameters to update expressions
+    params : iterable of shared variables, optional
+        The variables to apply momentum to. If omitted, will apply
+        momentum to all `updates.keys()`.
+    momentum : float or symbolic scalar, optional
+        The amount of momentum to apply. Higher momentum results in
+        smoothing over more update steps. Defaults to 0.9.
+
+    Returns
+    -------
+    OrderedDict
+        A copy of `updates` with momentum updates for all `params`.
+
+    Notes
+    -----
+    Higher momentum also results in larger update steps. To counter that,
+    you can optionally scale your learning rate by `1 - momentum`.
+
+    See Also
+    --------
+    momentum : Shortcut applying momentum to SGD updates
+    """
+    if params is None:
+        params = updates.keys()
+    updates = OrderedDict(updates)
+
+    for param in params:
+        value = param.get_value(borrow=True)
+        velocity = theano.shared(np.zeros(value.shape, dtype=value.dtype),
+                                 broadcastable=param.broadcastable)
+        x = momentum * velocity + updates[param]
+        updates[velocity] = x - param
+        updates[param] = x
 
     return updates
 
 
-# using the alternative formulation of nesterov momentum described at
-# https://github.com/lisa-lab/pylearn2/pull/136
-# such that the gradient can be evaluated at the current parameters.
-def nesterov_momentum(loss, all_params, learning_rate, momentum=0.9):
-    all_grads = theano.grad(loss, all_params)
-    updates = []
+def momentum(loss_or_grads, params, learning_rate, momentum=0.9):
+    """Stochastic Gradient Descent (SGD) updates with momentum.
 
-    for param_i, grad_i in zip(all_params, all_grads):
-        mparam_i = theano.shared(np.zeros(param_i.get_value().shape,
-                                          dtype=theano.config.floatX),
-                                 broadcastable=param_i.broadcastable)
-        v = momentum * mparam_i - learning_rate * grad_i  # new momemtum
-        w = param_i + momentum * v - learning_rate * grad_i  # new param values
-        updates.append((mparam_i, v))
-        updates.append((param_i, w))
+    Generates update expressions of the form:
+    * ``velocity := momentum * velocity - learning_rate * gradient``
+    * ``param := param + velocity``
+
+    Parameters
+    ----------
+    loss_or_grads : symbolic expression or list of expressions
+        A scalar loss expression, or a list of gradient expressions
+    params : list of shared variables
+        The variables to generate update expressions for
+    learning_rate : float or symbolic scalar
+        The learning rate controlling the size of update steps
+    momentum : float or symbolic scalar, optional
+        The amount of momentum to apply. Higher momentum results in
+        smoothing over more update steps. Defaults to 0.9.
+
+    Returns
+    -------
+    OrderedDict
+         A dictionary mapping each parameter to its update expression
+
+    Notes
+    -----
+    Higher momentum also results in larger update steps. To counter that,
+    you can optionally scale your learning rate by `1 - momentum`.
+
+    See Also
+    --------
+    apply_momentum : Generic function applying momentum to updates
+    nesterov_momentum : Nesterov's variant of SGD with momentum
+    """
+    updates = sgd(loss_or_grads, params, learning_rate)
+    return apply_momentum(updates, momentum=momentum)
+
+
+def apply_nesterov_momentum(updates, params=None, momentum=0.9):
+    """Returns a modified update dictionary including Nesterov momentum.
+
+    Generates update expressions of the form:
+    * ``velocity := momentum * velocity + updates[param] - param``
+    * ``param := param + momentum * velocity + updates[param] - param``
+
+    Parameters
+    ----------
+    updates : OrderedDict
+        A dictionary mapping parameters to update expressions
+    params : iterable of shared variables, optional
+        The variables to apply momentum to. If omitted, will apply
+        momentum to all `updates.keys()`.
+    momentum : float or symbolic scalar, optional
+        The amount of momentum to apply. Higher momentum results in
+        smoothing over more update steps. Defaults to 0.9.
+
+    Returns
+    -------
+    OrderedDict
+        A copy of `updates` with momentum updates for all `params`.
+
+    Notes
+    -----
+    Higher momentum also results in larger update steps. To counter that,
+    you can optionally scale your learning rate by `1 - momentum`.
+
+    The classic formulation of Nesterov momentum (or Nesterov accelerated
+    gradient) requires the gradient to be evaluated at the predicted next
+    position in parameter space. Here, we use the formulation described at
+    https://github.com/lisa-lab/pylearn2/pull/136#issuecomment-10381617,
+    which allows the gradient to be evaluated at the current parameters.
+
+    See Also
+    --------
+    nesterov_momentum : Shortcut applying Nesterov momentum to SGD updates
+    """
+    if params is None:
+        params = updates.keys()
+    updates = OrderedDict(updates)
+
+    for param in params:
+        value = param.get_value(borrow=True)
+        velocity = theano.shared(np.zeros(value.shape, dtype=value.dtype),
+                                 broadcastable=param.broadcastable)
+        x = momentum * velocity + updates[param] - param
+        updates[velocity] = x
+        updates[param] = momentum * x + updates[param]
 
     return updates
 
 
-def adagrad(loss, all_params, learning_rate=1.0, epsilon=1e-6):
+def nesterov_momentum(loss_or_grads, params, learning_rate, momentum=0.9):
+    """Stochastic Gradient Descent (SGD) updates with Nesterov momentum.
+
+    Generates update expressions of the form:
+    * ``velocity := momentum * velocity - learning_rate * gradient``
+    * ``param := param + momentum * velocity - learning_rate * gradient``
+
+    Parameters
+    ----------
+    loss_or_grads : symbolic expression or list of expressions
+        A scalar loss expression, or a list of gradient expressions
+    params : list of shared variables
+        The variables to generate update expressions for
+    learning_rate : float or symbolic scalar
+        The learning rate controlling the size of update steps
+    momentum : float or symbolic scalar, optional
+        The amount of momentum to apply. Higher momentum results in
+        smoothing over more update steps. Defaults to 0.9.
+
+    Returns
+    -------
+    OrderedDict
+         A dictionary mapping each parameter to its update expression
+
+    Notes
+    -----
+    Higher momentum also results in larger update steps. To counter that,
+    you can optionally scale your learning rate by `1 - momentum`.
+
+    The classic formulation of Nesterov momentum (or Nesterov accelerated
+    gradient) requires the gradient to be evaluated at the predicted next
+    position in parameter space. Here, we use the formulation described at
+    https://github.com/lisa-lab/pylearn2/pull/136#issuecomment-10381617,
+    which allows the gradient to be evaluated at the current parameters.
+
+    See Also
+    --------
+    apply_nesterov_momentum : Function applying momentum to updates
+    """
+    updates = sgd(loss_or_grads, params, learning_rate)
+    return apply_nesterov_momentum(updates, momentum=momentum)
+
+
+def adagrad(loss_or_grads, params, learning_rate=1.0, epsilon=1e-6):
     """
     epsilon is not included in the typical formula,
     See "Notes on AdaGrad" by Chris Dyer for more info.
     """
-    all_grads = theano.grad(loss, all_params)
-    all_accumulators = [theano.shared(np.zeros(param.get_value().shape,
-                                               dtype=theano.config.floatX),
-                                      broadcastable=param.broadcastable)
-                        for param in all_params]
+    grads = get_or_compute_grads(loss_or_grads, params)
+    updates = OrderedDict()
 
-    updates = []
-    for param_i, grad_i, acc_i in zip(all_params, all_grads, all_accumulators):
-        acc_i_new = acc_i + grad_i ** 2
-        updates.append((acc_i, acc_i_new))
-        updates.append((param_i, (param_i - learning_rate * grad_i /
-                                  T.sqrt(acc_i_new + epsilon))))
+    for param, grad in zip(params, grads):
+        value = param.get_value(borrow=True)
+        accu = theano.shared(np.zeros(value.shape, dtype=value.dtype),
+                             broadcastable=param.broadcastable)
+        accu_new = accu + grad ** 2
+        updates[accu] = accu_new
+        updates[param] = param - (learning_rate * grad /
+                                  T.sqrt(accu_new + epsilon))
 
     return updates
 
 
-def rmsprop(loss, all_params, learning_rate=1.0, rho=0.9, epsilon=1e-6):
+def rmsprop(loss_or_grads, params, learning_rate=1.0, rho=0.9, epsilon=1e-6):
     """
     epsilon is not included in the description in Hinton's video,
     but to prevent problems with relus repeatedly having 0 gradients,
@@ -83,23 +291,22 @@ def rmsprop(loss, all_params, learning_rate=1.0, rho=0.9, epsilon=1e-6):
     (formula at 5:20)
     also check http://climin.readthedocs.org/en/latest/rmsprop.html
     """
-    all_grads = theano.grad(loss, all_params)
-    all_accumulators = [theano.shared(np.zeros(param.get_value().shape,
-                                               dtype=theano.config.floatX),
-                                      broadcastable=param.broadcastable)
-                        for param in all_params]
+    grads = get_or_compute_grads(loss_or_grads, params)
+    updates = OrderedDict()
 
-    updates = []
-    for param_i, grad_i, acc_i in zip(all_params, all_grads, all_accumulators):
-        acc_i_new = rho * acc_i + (1 - rho) * grad_i ** 2
-        updates.append((acc_i, acc_i_new))
-        updates.append((param_i, (param_i - learning_rate * grad_i /
-                                  T.sqrt(acc_i_new + epsilon))))
+    for param, grad in zip(params, grads):
+        value = param.get_value(borrow=True)
+        accu = theano.shared(np.zeros(value.shape, dtype=value.dtype),
+                             broadcastable=param.broadcastable)
+        accu_new = rho * accu + (1 - rho) * grad ** 2
+        updates[accu] = accu_new
+        updates[param] = param - (learning_rate * grad /
+                                  T.sqrt(accu_new + epsilon))
 
     return updates
 
 
-def adadelta(loss, all_params, learning_rate=1.0, rho=0.95, epsilon=1e-6):
+def adadelta(loss_or_grads, params, learning_rate=1.0, rho=0.95, epsilon=1e-6):
     """
     in the paper, no learning rate is considered (so learning_rate=1.0).
     Probably best to keep it at this value.
@@ -112,95 +319,90 @@ def adadelta(loss, all_params, learning_rate=1.0, rho=0.95, epsilon=1e-6):
     see "Adadelta: an adaptive learning rate method" by Matthew Zeiler
     for more info.
     """
-    all_grads = theano.grad(loss, all_params)
-    all_accumulators = [theano.shared(np.zeros(param.get_value().shape,
-                                               dtype=theano.config.floatX),
-                                      broadcastable=param.broadcastable)
-                        for param in all_params]
+    grads = get_or_compute_grads(loss_or_grads, params)
+    updates = OrderedDict()
 
-    all_delta_accumulators = [
-        theano.shared(np.zeros(param.get_value().shape,
-                               dtype=theano.config.floatX),
-                      broadcastable=param.broadcastable)
-        for param in all_params
-    ]
+    for param, grad in zip(params, grads):
+        value = param.get_value(borrow=True)
+        # accu: accumulate gradient magnitudes
+        accu = theano.shared(np.zeros(value.shape, dtype=value.dtype),
+                             broadcastable=param.broadcastable)
+        # delta_accu: accumulate update magnitudes (recursively!)
+        delta_accu = theano.shared(np.zeros(value.shape, dtype=value.dtype),
+                                   broadcastable=param.broadcastable)
 
-    # all_accumulators: accumulate gradient magnitudes
-    # all_delta_accumulators: accumulate update magnitudes (recursive!)
+        # update accu (as in rmsprop)
+        accu_new = rho * accu + (1 - rho) * grad ** 2
+        updates[accu] = accu_new
 
-    updates = []
-    for param_i, grad_i, acc_i, acc_delta_i in zip(all_params,
-                                                   all_grads,
-                                                   all_accumulators,
-                                                   all_delta_accumulators):
-        acc_i_new = rho * acc_i + (1 - rho) * grad_i ** 2
-        updates.append((acc_i, acc_i_new))
+        # compute parameter update, using the 'old' delta_accu
+        update = (grad * T.sqrt(delta_accu + epsilon) /
+                  T.sqrt(accu_new + epsilon))
+        updates[param] = param - learning_rate * update
 
-        update_i = (grad_i * T.sqrt(acc_delta_i + epsilon) /
-                    # use the 'old' acc_delta here
-                    T.sqrt(acc_i_new + epsilon))
-        updates.append((param_i, param_i - learning_rate * update_i))
-
-        acc_delta_i_new = rho * acc_delta_i + (1 - rho) * update_i ** 2
-        updates.append((acc_delta_i, acc_delta_i_new))
+        # update delta_accu (as accu, but accumulating updates)
+        delta_accu_new = rho * delta_accu + (1 - rho) * update ** 2
+        updates[delta_accu] = delta_accu_new
 
     return updates
 
 
 def norm_constraint(tensor_var, max_norm, norm_axes=None, epsilon=1e-7):
-    """
-    Max weight norm constraints and gradient clipping
+    """Max weight norm constraints and gradient clipping
 
     This takes a TensorVariable and rescales it so that incoming weight
     norms are below a specified constraint value. Vectors violating the
     constraint are rescaled so that they are within the allowed range.
 
-    :parameters:
-        - tensor_var : TensorVariable
-            Theano expression for update, gradient, or other quantity.
-        - max_norm : scalar
-            This value sets the maximum allowed value of any norm in
-            `tensor_var`.
-        - norm_axes : sequence (list or tuple)
-            The axes over which to compute the norm.  This overrides the
-            default norm axes defined for the number of dimensions
-            in `tensor_var`. When this is not specified and `tensor_var` is a
-            matrix (2D), this is set to `(0,)`. If `tensor_var` is a 3D, 4D or
-            5D tensor, it is set to a tuple listing all axes but axis 0. The
-            former default is useful for working with dense layers, the latter
-            is useful for 1D, 2D and 3D convolutional layers.
-            (Optional)
-        - epsilon : scalar
-            Value used to prevent numerical instability when dividing by
-            very small or zero norms.
-            (Optional)
+    Parameters
+    ----------
+    tensor_var : TensorVariable
+        Theano expression for update, gradient, or other quantity.
+    max_norm : scalar
+        This value sets the maximum allowed value of any norm in
+        `tensor_var`.
+    norm_axes : sequence (list or tuple)
+        The axes over which to compute the norm.  This overrides the
+        default norm axes defined for the number of dimensions
+        in `tensor_var`. When this is not specified and `tensor_var` is a
+        matrix (2D), this is set to `(0,)`. If `tensor_var` is a 3D, 4D or
+        5D tensor, it is set to a tuple listing all axes but axis 0. The
+        former default is useful for working with dense layers, the latter
+        is useful for 1D, 2D and 3D convolutional layers.
+        (Optional)
+    epsilon : scalar, optional
+        Value used to prevent numerical instability when dividing by
+        very small or zero norms.
 
-    :returns:
-        - constrained_output : TensorVariable
-            Input `tensor_var` with rescaling applied to weight vectors
-            that violate the specified constraints.
+    Returns
+    -------
+    TensorVariable
+        Input `tensor_var` with rescaling applied to weight vectors
+        that violate the specified constraints.
 
-    :usage:
-        >>> param = theano.shared(
-        ...     np.random.randn(100, 200).astype(theano.config.floatX))
-        >>> update = param + 100
-        >>> update = norm_constraint(update, 10)
-        >>> func = theano.function([], [], updates=[(param, update)])
-        >>> # Apply constrained update
-        >>> _ = func()
-        >>> from lasagne.utils import compute_norms
-        >>> norms = compute_norms(param.get_value())
-        >>> np.isclose(np.max(norms), 10)
-        True
+    Examples
+    --------
+    >>> param = theano.shared(
+    ...     np.random.randn(100, 200).astype(theano.config.floatX))
+    >>> update = param + 100
+    >>> update = norm_constraint(update, 10)
+    >>> func = theano.function([], [], updates=[(param, update)])
+    >>> # Apply constrained update
+    >>> _ = func()
+    >>> from lasagne.utils import compute_norms
+    >>> norms = compute_norms(param.get_value())
+    >>> np.isclose(np.max(norms), 10)
+    True
 
-    :note:
-        When `norm_axes` is not specified, the axes over which the norm is
-        computed depend on the dimensionality of the input variable. If it is
-        2D, it is assumed to come from a dense layer, and the norm is computed
-        over axis 0. If it is 3D, 4D or 5D, it is assumed to come from a
-        convolutional layer and the norm is computed over all trailing axes
-        beyond axis 0. For other uses, you should explicitly specify the axes
-        over which to compute the norm using `norm_axes`.
+    Notes
+    -----
+    When `norm_axes` is not specified, the axes over which the norm is
+    computed depend on the dimensionality of the input variable. If it is
+    2D, it is assumed to come from a dense layer, and the norm is computed
+    over axis 0. If it is 3D, 4D or 5D, it is assumed to come from a
+    convolutional layer and the norm is computed over all trailing axes
+    beyond axis 0. For other uses, you should explicitly specify the axes
+    over which to compute the norm using `norm_axes`.
     """
     ndim = tensor_var.ndim
 


### PR DESCRIPTION
This pulls out `apply_momentum` and `apply_nesterov_momentum` as I suggested in https://github.com/benanne/Lasagne/issues/190#issuecomment-88960154. Also it changes the update functions to accept either a cost expression or a list of gradients, and to return OrderedDicts instead of `(param, update)` tuple lists. Finally, it adds numpy-style docstrings to `sgd` and the four `momentum` functions, and converts the `norm_constraint` docstring to numpy format.